### PR TITLE
issue101: updating the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,14 @@ We use Travis to ensure our tests are passing all the time.
 
 The _dev-files_ dir contains configurations for the Eclipse and the IDEA formatters (I took them from the JavaParser project, thanks guys!).
 
-An overview of the architecture of the project is available in Design.MD
+The project is structured in this way:
+
+* We have nodes that wrap the JavaParser nodes (but can also wrap Javassist or JRE nodes)
+* The nodes contain all the information of the AST
+* Context classes contain the logic to solve methods, symbols and types in the respective context.
+* Default fallback behavior: ask the parent context for help (so if a variable identifier cannot be solved inside a MethodContext the underlying ClassDeclarationContext is asked and maybe we find out that the identifier actually refers to a field.
+
+A more detailed description of the architecture of the project is available in [Design.MD](https://github.com/javaparser/javasymbolsolver/blob/master/Design.MD)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,19 @@
 [![Maven Central](https://img.shields.io/maven-central/v/me.tomassetti/java-symbol-solver-core.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22me.tomassetti%22%20AND%20a%3A%22java-symbol-solver-core%22)
 [![Build Status](https://travis-ci.org/javaparser/javasymbolsolver.svg?branch=master)](https://travis-ci.org/javaparser/javasymbolsolver)
 
-A Symbol Solver for Java built on top of [JavaParser](https://github.com/javaparser/javaparser/).
+A Symbol Solver for Java built on top of [JavaParser](https://github.com/javaparser/javaparser/) from the same team of committers.
 
-## What can you use a Symbol Solver for?
+## How this complement JavaParser?
+
+JavaParser is a parser: given a source file it recognizes the different syntatic
+element and produce an Abstract Syntax Tree (AST).
+
+JavaSymbolSolver analyzes that AST and find the declarations connected to each element.
+
+`foo` in the AST is just a name, JavaSymbolSolver can tell you if it refers to a parameter, a local variable, a field. It can also give you the type, tell you where
+the element has been defined and so on.
+
+## What can I use it for?
 
 A Symbol Solver can associate a symbol in your code to its declaration. This is necessary to verify the type of an expression or to find the usage of a symbol (like a field or a local variable):
 
@@ -21,7 +31,7 @@ while (true) {
 
 In the expression `a + 1` a parser (like JavaParser) is not able to tell us to which definition of `a` we are referring to and consequently it cannot tell us the type of `a`. The JavaSymbolSolver is able to do so.
 
-## How can I use it?
+## How can I use it? Shoe me some code!
 
 Take a look at `JavaParserFacade`. For example you can use it to find the type of an expression:
 
@@ -53,11 +63,13 @@ _We plan to write soon more examples and tutorials._
 
 ## Status of the project
 
-This project is young but we have already tried it on significant projects and it is doing well so far. 
+This project is more recent of JavaParser but it has been receiving some attention and
+it has been improving a lot recently.
+
 It supports all features of Java 8 (lambdas, generic, type inference, etc.). 
 Of course we expect some bugs to emerge from time to time but we are committed to help users solve them as soon as possible.
 
-TODO add link to COATI
+It has been also used in a commercial product from [Coati](https://www.coati.io/).
 
 ## License
 
@@ -65,10 +77,9 @@ This code is available under the Apache License.
 
 ## Development
 
-We use Travis to ensure our tests are passing all the time and we use [Walkmod](http://walkmod.com) to ensure code conventions are respected.
-The _dev-files_ dir contains configurations for the Eclipse and the IDEA formatters (I took them from the JavaParser project, thanks guys!).
+We use Travis to ensure our tests are passing all the time.
 
-[![Walkmod Status](http://walkmod.com/pulls/ftomassetti/java-symbol-solver/master/status.svg)](http://walkmod.com)
+The _dev-files_ dir contains configurations for the Eclipse and the IDEA formatters (I took them from the JavaParser project, thanks guys!).
 
 An overview of the architecture of the project is available in Design.MD
 
@@ -76,5 +87,6 @@ An overview of the architecture of the project is available in Design.MD
 
 I would absolutely love every possible kind of contributions: if you have questions, ideas, need help or want to propose a change just open an issue. Pull-requests are greatly appreciated.
 
-Thanks to Malte Langkabel, Matozoid, Ayman Abdelghany, Evan Rittenhouse, Rachel Pau, selslack and Simone Basso for their contributions!
+Thanks to Malte Langkabel, Ayman Abdelghany, Evan Rittenhouse, Rachel Pau, Pavel Eremeev, Simone Basso and Rafael Vargas for their contributions!
 
+The project has been created by Federico Tomassetti and it is currently co-maintained by the JavaParser team.


### PR DESCRIPTION
We need to update the Readme to reflect the fact JavaSymbolSolver is now part of JavaParser.

@matozoid @mlangkabel comments on this one?