### PR TITLE
Update for Javaparser 3.0.0-RC.4

### DIFF
--- a/java-symbol-solver-core/build.gradle
+++ b/java-symbol-solver-core/build.gradle
@@ -1,6 +1,6 @@
 description = ''
 dependencies {
-    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.0-RC.3'
+    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.0-RC.4'
     compile group: 'org.javassist', name: 'javassist', version: '3.19.0-GA'
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
     compile project(':java-symbol-solver-model')

--- a/java-symbol-solver-core/pom.xml
+++ b/java-symbol-solver-core/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
-            <version>3.0.0-RC.3</version>
+            <version>3.0.0-RC.4</version>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/SourceFileInfoExtractor.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/SourceFileInfoExtractor.java
@@ -26,7 +26,7 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.imports.ImportDeclaration;
+import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.model.declarations.TypeDeclaration;

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -156,10 +156,11 @@ public class JavaParserFacade {
 
         solveArguments(explicitConstructorInvocationStmt, explicitConstructorInvocationStmt.getArguments(), solveLambdas, argumentTypes, placeholders);
 
-        ClassOrInterfaceDeclaration classNode = explicitConstructorInvocationStmt.getAncestorOfType(ClassOrInterfaceDeclaration.class);
-        if (classNode == null) {
+        Optional<ClassOrInterfaceDeclaration> optAncestor = explicitConstructorInvocationStmt.getAncestorOfType(ClassOrInterfaceDeclaration.class);
+        if (!optAncestor.isPresent()) {
             return SymbolReference.unsolved(ConstructorDeclaration.class);
         }
+        ClassOrInterfaceDeclaration classNode = optAncestor.get();
         TypeDeclaration typeDecl = null;
         if (!explicitConstructorInvocationStmt.isThis()) {
             Type classDecl = JavaParserFacade.get(typeSolver).convert(classNode.getExtendedTypes(0), classNode);

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
@@ -332,8 +332,8 @@ public class ReflectionClassDeclarationTest {
         ReferenceType interfaze = null;
 
         interfaze = constructorDeclaration.getInterfaces().get(0);
-        assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithJavaDoc", interfaze.getQualifiedName());
-        assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", interfaze.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithJavaDoc.N").get().asReferenceType().getQualifiedName());
+        assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithJavadoc", interfaze.getQualifiedName());
+        assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", interfaze.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithJavadoc.N").get().asReferenceType().getQualifiedName());
 
         interfaze = constructorDeclaration.getInterfaces().get(1);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithDeclaration", interfaze.getQualifiedName());
@@ -377,7 +377,7 @@ public class ReflectionClassDeclarationTest {
                 "com.github.javaparser.ast.nodeTypes.NodeWithImplements",
                 "com.github.javaparser.ast.nodeTypes.NodeWithSimpleName",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers",
-                "com.github.javaparser.ast.nodeTypes.NodeWithJavaDoc",
+                "com.github.javaparser.ast.nodeTypes.NodeWithJavadoc",
                 "com.github.javaparser.ast.nodeTypes.NodeWithTypeParameters",
                 "com.github.javaparser.ast.nodeTypes.NodeWithMembers",
                 "com.github.javaparser.ast.observer.Observable"), coid.getAllInterfaces().stream().map(i -> i.getQualifiedName()).collect(Collectors.toSet()));
@@ -391,8 +391,8 @@ public class ReflectionClassDeclarationTest {
         ReferenceType interfaze = null;
 
         interfaze = constructorDeclaration.getAllInterfaces().get(0);
-        assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithJavaDoc", interfaze.getQualifiedName());
-        assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", interfaze.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithJavaDoc.N").get().asReferenceType().getQualifiedName());
+        assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithJavadoc", interfaze.getQualifiedName());
+        assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", interfaze.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithJavadoc.N").get().asReferenceType().getQualifiedName());
 
         interfaze = constructorDeclaration.getAllInterfaces().get(1);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithDeclaration", interfaze.getQualifiedName());
@@ -451,8 +451,8 @@ public class ReflectionClassDeclarationTest {
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.body.BodyDeclaration.T").get().asReferenceType().getQualifiedName());
 
         ancestor = constructorDeclaration.getAncestors().get(1);
-        assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithJavaDoc", ancestor.getQualifiedName());
-        assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithJavaDoc.N").get().asReferenceType().getQualifiedName());
+        assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithJavadoc", ancestor.getQualifiedName());
+        assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithJavadoc.N").get().asReferenceType().getQualifiedName());
 
         ancestor = constructorDeclaration.getAncestors().get(2);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithDeclaration", ancestor.getQualifiedName());
@@ -523,8 +523,8 @@ public class ReflectionClassDeclarationTest {
         assertEquals("java.lang.Object", ancestor.getQualifiedName());
 
         ancestor = constructorDeclaration.getAllAncestors().get(8);
-        assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithJavaDoc", ancestor.getQualifiedName());
-        assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithJavaDoc.N").get().asReferenceType().getQualifiedName());
+        assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithJavadoc", ancestor.getQualifiedName());
+        assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithJavadoc.N").get().asReferenceType().getQualifiedName());
 
         ancestor = constructorDeclaration.getAllAncestors().get(9);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithDeclaration", ancestor.getQualifiedName());

--- a/java-symbol-solver-examples/build.gradle
+++ b/java-symbol-solver-examples/build.gradle
@@ -1,7 +1,7 @@
 
 description = ''
 dependencies {
-    compile group: 'com.github.javaparser', name: 'javaparser-core', version:'3.0.0-RC.3'
+    compile group: 'com.github.javaparser', name: 'javaparser-core', version:'3.0.0-RC.4'
     compile group: 'org.javassist', name: 'javassist', version:'3.19.0-GA'
     compile group: 'com.google.guava', name: 'guava', version:'18.0'
   compile project(':java-symbol-solver-core')

--- a/java-symbol-solver-examples/pom.xml
+++ b/java-symbol-solver-examples/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.github.javaparser</groupId>
       <artifactId>javaparser-core</artifactId>
-      <version>3.0.0-RC.3</version>
+      <version>3.0.0-RC.4</version>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>

--- a/java-symbol-solver-logic/build.gradle
+++ b/java-symbol-solver-logic/build.gradle
@@ -1,6 +1,6 @@
 description = ''
 dependencies {
-    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.0-RC.3'
+    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.0-RC.4'
     compile group: 'org.javassist', name: 'javassist', version: '3.19.0-GA'
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
     compile project(':java-symbol-solver-model')

--- a/java-symbol-solver-logic/pom.xml
+++ b/java-symbol-solver-logic/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
-            <version>3.0.0-RC.3</version>
+            <version>3.0.0-RC.4</version>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>

--- a/java-symbol-solver-model/build.gradle
+++ b/java-symbol-solver-model/build.gradle
@@ -16,7 +16,7 @@
 
 description = ''
 dependencies {
-    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.0-RC.3'
+    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.0-RC.4'
     compile group: 'org.javassist', name: 'javassist', version: '3.19.0-GA'
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
     compile group: 'com.javaslang', name: 'javaslang', version: '2.0.0-beta'

--- a/java-symbol-solver-model/pom.xml
+++ b/java-symbol-solver-model/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
-            <version>3.0.0-RC.3</version>
+            <version>3.0.0-RC.4</version>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>


### PR DESCRIPTION
Updating this for Javaparser 3.0.0-RC.4 as it's the one now on Maven central. I had to change the `ImportDeclaration`s back to the single node version, other than that most changes were minor