### PR TITLE
Update for JavaParser 3.0.0

### DIFF
--- a/java-symbol-solver-core/build.gradle
+++ b/java-symbol-solver-core/build.gradle
@@ -1,6 +1,6 @@
 description = ''
 dependencies {
-    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.0-RC.4'
+    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.0'
     compile group: 'org.javassist', name: 'javassist', version: '3.19.0-GA'
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
     compile project(':java-symbol-solver-model')

--- a/java-symbol-solver-core/pom.xml
+++ b/java-symbol-solver-core/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
-            <version>3.0.0-RC.4</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -392,12 +392,13 @@ public class JavaParserFacade {
                     //        the MethodDeclaration of filter is:
                     //        Stream<T> filter(Predicate<? super T> predicate)
                     //        but T in this case is equal to String
-                    if (callExpr.getScope() != null) {
+                    if (callExpr.getScope().isPresent()) {
+                        Expression scope = callExpr.getScope().get();
 
                         // If it is a static call we should not try to get the type of the scope
                         boolean staticCall = false;
-                        if (callExpr.getScope() instanceof NameExpr) {
-                            NameExpr nameExpr = (NameExpr) callExpr.getScope();
+                        if (scope instanceof NameExpr) {
+                            NameExpr nameExpr = (NameExpr) scope;
                             try {
                                 JavaParserFactory.getContext(nameExpr, typeSolver).solveType(nameExpr.getName().getId(), typeSolver);
                                 staticCall = true;
@@ -407,7 +408,7 @@ public class JavaParserFacade {
                         }
 
                         if (!staticCall) {
-                            Type scopeType = JavaParserFacade.get(typeSolver).getType(callExpr.getScope());
+                            Type scopeType = JavaParserFacade.get(typeSolver).getType(scope);
                             if (scopeType.isReferenceType()) {
                                 result = scopeType.asReferenceType().useThisTypeParametersOnTheGivenType(result);
                             }

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
@@ -387,7 +387,7 @@ public class ContextTest extends AbstractTest {
         com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Navigator");
         MethodDeclaration method = Navigator.demandMethod(clazz, "findType");
         MethodCallExpr callToGetName = Navigator.findMethodCall(method, "getName");
-        Expression referenceToT = callToGetName.getScope();
+        Expression referenceToT = callToGetName.getScope().get();
 
         String pathToJar = adaptPath("src/test/resources/javaparser-core-2.1.0.jar");
         TypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver(), new JarTypeSolver(pathToJar));

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/GenericsResolutionTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/GenericsResolutionTest.java
@@ -260,7 +260,7 @@ public class GenericsResolutionTest extends AbstractResolutionTest {
         MethodCallExpr call = Navigator.findMethodCall(method, "cast");
 
         TypeSolver typeSolver = new ReflectionTypeSolver();
-        Expression scope = call.getScope();
+        Expression scope = call.getScope().get();
         Type type = JavaParserFacade.get(typeSolver).getType(scope);
 
         //System.out.println(typeUsage);

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/StatementContextResolutionTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/StatementContextResolutionTest.java
@@ -80,7 +80,7 @@ public class StatementContextResolutionTest extends AbstractResolutionTest {
 
         TypeSolver typeSolver = new ReflectionTypeSolver();
 
-        SymbolReference<? extends ValueDeclaration> ref = JavaParserFacade.get(typeSolver).solve(call.getScope());
+        SymbolReference<? extends ValueDeclaration> ref = JavaParserFacade.get(typeSolver).solve(call.getScope().get());
         assertTrue(ref.isSolved());
         assertEquals("java.util.List<Comment>", ref.getCorrespondingDeclaration().getType().describe());
 
@@ -97,7 +97,7 @@ public class StatementContextResolutionTest extends AbstractResolutionTest {
 
         TypeSolver typeSolver = new ReflectionTypeSolver();
 
-        SymbolReference<? extends ValueDeclaration> ref = JavaParserFacade.get(typeSolver).solve(call.getScope());
+        SymbolReference<? extends ValueDeclaration> ref = JavaParserFacade.get(typeSolver).solve(call.getScope().get());
         assertTrue(ref.isSolved());
         assertEquals("java.util.List<Comment>", ref.getCorrespondingDeclaration().getType().describe());
 

--- a/java-symbol-solver-examples/build.gradle
+++ b/java-symbol-solver-examples/build.gradle
@@ -1,7 +1,7 @@
 
 description = ''
 dependencies {
-    compile group: 'com.github.javaparser', name: 'javaparser-core', version:'3.0.0-RC.4'
+    compile group: 'com.github.javaparser', name: 'javaparser-core', version:'3.0.0'
     compile group: 'org.javassist', name: 'javassist', version:'3.19.0-GA'
     compile group: 'com.google.guava', name: 'guava', version:'18.0'
   compile project(':java-symbol-solver-core')

--- a/java-symbol-solver-examples/pom.xml
+++ b/java-symbol-solver-examples/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.github.javaparser</groupId>
       <artifactId>javaparser-core</artifactId>
-      <version>3.0.0-RC.4</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>

--- a/java-symbol-solver-logic/build.gradle
+++ b/java-symbol-solver-logic/build.gradle
@@ -1,6 +1,6 @@
 description = ''
 dependencies {
-    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.0-RC.4'
+    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.0'
     compile group: 'org.javassist', name: 'javassist', version: '3.19.0-GA'
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
     compile project(':java-symbol-solver-model')

--- a/java-symbol-solver-logic/pom.xml
+++ b/java-symbol-solver-logic/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
-            <version>3.0.0-RC.4</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>

--- a/java-symbol-solver-model/build.gradle
+++ b/java-symbol-solver-model/build.gradle
@@ -16,7 +16,7 @@
 
 description = ''
 dependencies {
-    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.0-RC.4'
+    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.0'
     compile group: 'org.javassist', name: 'javassist', version: '3.19.0-GA'
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
     compile group: 'com.javaslang', name: 'javaslang', version: '2.0.0-beta'

--- a/java-symbol-solver-model/pom.xml
+++ b/java-symbol-solver-model/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
-            <version>3.0.0-RC.4</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>


### PR DESCRIPTION
Further to #130, pushing this to `3.0.0` (non *release-candidate* version) with very few changes needed.