### PR TITLE
Fixed issue when converting wildcard type with super bound

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -740,7 +740,7 @@ public class JavaParserFacade {
             if (wildcardType.getExtendedTypes().isPresent() && !wildcardType.getSuperTypes().isPresent()) {
                 return Wildcard.extendsBound(convertToUsage(wildcardType.getExtendedTypes().get(), context)); // removed (ReferenceTypeImpl)
             } else if (!wildcardType.getExtendedTypes().isPresent() && wildcardType.getSuperTypes().isPresent()) {
-                return Wildcard.extendsBound(convertToUsage(wildcardType.getSuperTypes().get(), context)); // removed (ReferenceTypeImpl)
+                return Wildcard.superBound(convertToUsage(wildcardType.getSuperTypes().get(), context)); // removed (ReferenceTypeImpl)
             } else if (!wildcardType.getExtendedTypes().isPresent() && !wildcardType.getSuperTypes().isPresent()) {
                 return Wildcard.UNBOUNDED;
             } else {

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/ConvertToUsageTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/ConvertToUsageTest.java
@@ -1,0 +1,41 @@
+package com.github.javaparser.symbolsolver.javaparsermodel;
+
+import com.github.javaparser.ParseException;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ConvertToUsageTest extends AbstractResolutionTest {
+
+    TypeSolver typeSolver = new ReflectionTypeSolver();
+
+    @Test
+    public void testConvertTypeToUsage() throws ParseException {
+        CompilationUnit cu = parseSample("LocalTypeDeclarations");
+        List<NameExpr> n = cu.getNodesByType(NameExpr.class);
+
+        assertEquals("int", usageDescribe(n, "a"));
+        assertEquals("java.lang.Integer", usageDescribe(n, "b"));
+        assertEquals("java.lang.Class<java.lang.Integer>", usageDescribe(n, "c"));
+        assertEquals("java.lang.Class<? super java.lang.Integer>", usageDescribe(n, "d"));
+        assertEquals("java.lang.Class<? extends java.lang.Integer>", usageDescribe(n, "e"));
+        assertEquals("java.lang.Class<? extends java.lang.Class<? super java.lang.Class<? extends java.lang.Integer>>>", usageDescribe(n, "f"));
+        assertEquals("java.lang.Class<? super java.lang.Class<? extends java.lang.Class<? super java.lang.Integer>>>", usageDescribe(n, "g"));
+
+
+    }
+
+    private String usageDescribe(List<NameExpr> n, String name){
+        return n.stream().filter(x -> x.getNameAsString().equals(name))
+                .map(JavaParserFacade.get(typeSolver)::getType)
+                .map(t -> t.describe())
+                .findFirst().orElse(null);
+    }
+}

--- a/java-symbol-solver-core/src/test/resources/LocalTypeDeclarations.java.txt
+++ b/java-symbol-solver-core/src/test/resources/LocalTypeDeclarations.java.txt
@@ -1,0 +1,14 @@
+class Foo {
+
+    void bar(){
+        int a;
+        Integer b;
+        Class<Integer> c;
+        Class<? super Integer> d;
+        Class<? extends Integer> e;
+        Class<? extends Class<? super Class<? extends Integer>>> f;
+        Class<? super Class<? extends Class<? super Integer>>> g;
+        a;b;c;d;e;f;g;
+    }
+
+}


### PR DESCRIPTION
Fixes very small bug on `convertToUsage` which caused `super` wildcard bounds to be created as `extends` (and added an accompanying test).

eg.
`
Class<? super Number> c;
`

Resolves to:
`java.util.Class<? extends java.lang.Number>`