### PR TITLE
Update JavaParserFacade.java

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -82,6 +82,14 @@ public class JavaParserFacade {
         this.symbolSolver = new SymbolSolver(typeSolver);
     }
 
+    public getTypeSolver() {
+        return typeSolver;
+    }
+
+    public getSymbolSolver() {
+        return symbolSolver;
+    }
+
     public static JavaParserFacade get(TypeSolver typeSolver) {
         if (!instances.containsKey(typeSolver)) {
             instances.put(typeSolver, new JavaParserFacade(typeSolver));

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -82,11 +82,11 @@ public class JavaParserFacade {
         this.symbolSolver = new SymbolSolver(typeSolver);
     }
 
-    public getTypeSolver() {
+    public TypeSolver getTypeSolver() {
         return typeSolver;
     }
 
-    public getSymbolSolver() {
+    public SymbolSolver getSymbolSolver() {
         return symbolSolver;
     }
 


### PR DESCRIPTION
Added getters for TypeSolver & SymbolSolver to JavaParserFacade.

In my program I create a CombinedTypeSolver which sets all the different types that would need to be solved. Later in the program while visiting source code nodes I would like to use the TypeSolver to get the TypeDeclaration of a "java.lang.StringBuilder". Currently JavaParserFacade is provided when visiting source code nodes but it does not expose the TypeSolver or SymbolSolver it uses when solving symbols. It would be beneficial if it at least made TypeSolver accessible.

Please let me know if I've done anything wrong or need to improve something. My first pull request.