### PR TITLE
Fix issue with reference type assignability to boxed type

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeImpl.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeImpl.java
@@ -22,6 +22,7 @@ import com.github.javaparser.symbolsolver.model.declarations.MethodDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.ReferenceTypeDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.TypeParameterDeclaration;
 import com.github.javaparser.symbolsolver.model.methods.MethodUsage;
+import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 import java.util.HashSet;
@@ -86,7 +87,12 @@ public class ReferenceTypeImpl extends ReferenceType {
             if (this.getQualifiedName().equals(Object.class.getCanonicalName())) {
                 return true;
             } else {
-                return isCorrespondingBoxingType(other.describe());
+                // Check if 'other' can be boxed to match this type
+                if (isCorrespondingBoxingType(other.describe())) return true;
+
+                // Resolve the boxed type and check if it can be assigned via widening reference conversion
+                SymbolReference<ReferenceTypeDeclaration> type = typeSolver.tryToSolveType(other.asPrimitive().getBoxTypeQName());
+                return type.getCorrespondingDeclaration().canBeAssignedTo(super.typeDeclaration);
             }
         }
         if (other instanceof LambdaArgumentTypePlaceholder) {

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
@@ -189,6 +189,22 @@ public class ReferenceTypeTest {
     }
 
     @Test
+    public void testIsAssignableByBoxedPrimitive(){
+        ReferenceType numberType = new ReferenceTypeImpl(new ReflectionClassDeclaration(Number.class, typeSolver),typeSolver);
+        ReferenceType intType = new ReferenceTypeImpl(new ReflectionClassDeclaration(Integer.class, typeSolver),typeSolver);
+        ReferenceType doubleType = new ReferenceTypeImpl(new ReflectionClassDeclaration(Double.class, typeSolver),typeSolver);
+
+        assertEquals(true,  numberType.isAssignableBy(PrimitiveType.INT));
+        assertEquals(true,  numberType.isAssignableBy(PrimitiveType.DOUBLE));
+        assertEquals(true,  numberType.isAssignableBy(PrimitiveType.SHORT));
+        assertEquals(true,  numberType.isAssignableBy(PrimitiveType.LONG));
+        assertEquals(true,  numberType.isAssignableBy(PrimitiveType.FLOAT));
+        assertEquals(false, numberType.isAssignableBy(PrimitiveType.BOOLEAN));
+        assertEquals(true,  intType.isAssignableBy(PrimitiveType.INT));
+        assertEquals(true,  doubleType.isAssignableBy(PrimitiveType.DOUBLE));
+    }
+
+    @Test
     public void testIsAssignableByGenerics() {
         assertEquals(false, listOfStrings.isAssignableBy(listOfWildcardExtendsString));
         assertEquals(false, listOfStrings.isAssignableBy(listOfWildcardExtendsString));


### PR DESCRIPTION
The `isAssignableBy` method in `ReferenceTypeImpl` does not consider boxing followed by widening reference conversion.

ie. int -> Integer -> Number

For example doing `JavaParserFacade.get(combinedTypeSolver).getType(methodCallExpr);` (on the `foo(1)` method call) throws an error `Method 'foo' cannot be resolved in context ...`


```java
void foo(Number a){
    System.out.println("Run.");
}

void bar(){
    foo(1);
}
```

Added a fix for this plus a test. (We could arguably get rid of `isCorrespondingBoxingType` but I just kept it in case it returns faster for the common case)