### PR TITLE
Add object type check to avoid infinite ancestor recursion

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -75,7 +75,7 @@ public class JavaParserTypeDeclarationAdapter {
                 .filter(m -> m.getName().equals(name))
                 .collect(Collectors.toList());
         // We want to avoid infinite recursion in case of Object having Object as ancestor
-        if (!typeDeclaration.getQualifiedName().equals(Object.class.getCanonicalName())) {
+        if (!Object.class.getCanonicalName().equals(typeDeclaration.getQualifiedName())) {
             for (ReferenceType ancestor : typeDeclaration.getAncestors()) {
                 SymbolReference<MethodDeclaration> res = MethodResolutionLogic
                         .solveMethodInType(ancestor.getTypeDeclaration(), name, argumentsTypes, typeSolver);

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -74,16 +74,20 @@ public class JavaParserTypeDeclarationAdapter {
         List<MethodDeclaration> candidateMethods = typeDeclaration.getDeclaredMethods().stream()
                 .filter(m -> m.getName().equals(name))
                 .collect(Collectors.toList());
-
-        for (ReferenceType ancestor : typeDeclaration.getAncestors()) {
-            SymbolReference<MethodDeclaration> res = MethodResolutionLogic.solveMethodInType(ancestor.getTypeDeclaration(), name, argumentsTypes, typeSolver);
-            // consider methods from superclasses and only default methods from interfaces : not true, we should keep abstract as a valid candidate
-            // abstract are removed in MethodResolutionLogic.isApplicable is necessary
-            if (res.isSolved()&& (!ancestor.getTypeDeclaration().isInterface() || res.getCorrespondingDeclaration().isDefaultMethod())) {
-                candidateMethods.add(res.getCorrespondingDeclaration());
+        // We want to avoid infinite recursion in case of Object having Object as ancestor
+        if (!typeDeclaration.getQualifiedName().equals(Object.class.getCanonicalName())) {
+            for (ReferenceType ancestor : typeDeclaration.getAncestors()) {
+                SymbolReference<MethodDeclaration> res = MethodResolutionLogic
+                        .solveMethodInType(ancestor.getTypeDeclaration(), name, argumentsTypes, typeSolver);
+                // consider methods from superclasses and only default methods from interfaces :
+                // not true, we should keep abstract as a valid candidate
+                // abstract are removed in MethodResolutionLogic.isApplicable is necessary
+                if (res.isSolved() && (!ancestor.getTypeDeclaration().isInterface()
+                        || res.getCorrespondingDeclaration().isDefaultMethod())) {
+                    candidateMethods.add(res.getCorrespondingDeclaration());
+                }
             }
         }
-
         // We want to avoid infinite recursion when a class is using its own method
         // see issue #75
         if (candidateMethods.isEmpty()) {

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -112,7 +112,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
 
         ClassDeclaration superclass = (ClassDeclaration) this.getSuperClass().getTypeDeclaration();
         if (superclass!=this)
-        	fields.addAll(superclass.getAllFields());
+            fields.addAll(superclass.getAllFields());
 
         getInterfaces().forEach(interf -> interf.getTypeDeclaration().getAllFields().forEach(f -> {
             fields.add(f);
@@ -218,8 +218,14 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
             return true;
         }
         ClassDeclaration superclass = (ClassDeclaration) getSuperClass().getTypeDeclaration();
-        if (superclass != null && superclass.canBeAssignedTo(other)) {
-            return true;
+        if (superclass != null) {
+            // We want to avoid infinite recursion in case of Object having Object as ancestor
+            if (superclass.getQualifiedName().equals(Object.class.getCanonicalName())) {
+                return true;
+            }
+            if (superclass.canBeAssignedTo(other)) {
+                return true;
+            }
         }
 
         if (this.wrappedNode.getImplementedTypes() != null) {

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -220,7 +220,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
         ClassDeclaration superclass = (ClassDeclaration) getSuperClass().getTypeDeclaration();
         if (superclass != null) {
             // We want to avoid infinite recursion in case of Object having Object as ancestor
-            if (superclass.getQualifiedName().equals(Object.class.getCanonicalName())) {
+            if (Object.class.getCanonicalName().equals(superclass.getQualifiedName())) {
                 return true;
             }
             if (superclass.canBeAssignedTo(other)) {

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/ReferenceTypeDeclaration.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/ReferenceTypeDeclaration.java
@@ -39,13 +39,16 @@ public interface ReferenceTypeDeclaration extends TypeDeclaration, TypeParametri
      * The list of all the ancestors of the current declaration, direct and indirect.
      * This list does not contains duplicates with the exacting same type parameters.
      */
-    default List<ReferenceType> getAllAncestors() {
+    default List<ReferenceType> getAllAncestors() {     
         List<ReferenceType> ancestors = new ArrayList<>();
-        for (ReferenceType ancestor : getAncestors()) {
-            ancestors.add(ancestor);
-            for (ReferenceType inheritedAncestor : ancestor.getAllAncestors()) {
-                if (!ancestors.contains(inheritedAncestor)) {
-                    ancestors.add(inheritedAncestor);
+        // We want to avoid infinite recursion in case of Object having Object as ancestor
+        if (!(getQualifiedName().equals(Object.class.getCanonicalName()))) {            
+            for (ReferenceType ancestor : getAncestors()) {
+                ancestors.add(ancestor);    
+                for (ReferenceType inheritedAncestor : ancestor.getAllAncestors()) {
+                    if (!ancestors.contains(inheritedAncestor)) {
+                        ancestors.add(inheritedAncestor);
+                    }
                 }
             }
         }

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/ReferenceTypeDeclaration.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/ReferenceTypeDeclaration.java
@@ -42,7 +42,7 @@ public interface ReferenceTypeDeclaration extends TypeDeclaration, TypeParametri
     default List<ReferenceType> getAllAncestors() {     
         List<ReferenceType> ancestors = new ArrayList<>();
         // We want to avoid infinite recursion in case of Object having Object as ancestor
-        if (!(getQualifiedName().equals(Object.class.getCanonicalName()))) {            
+        if (!(Object.class.getCanonicalName().equals(getQualifiedName()))) {       
             for (ReferenceType ancestor : getAncestors()) {
                 ancestors.add(ancestor);    
                 for (ReferenceType inheritedAncestor : ancestor.getAllAncestors()) {


### PR DESCRIPTION
Referencing issue #163 
When traversing the jdk java files, the symbol solver is stuck on resolving the type Object. As Object seems to have the ancestor Object, an infinite loop is created. I modified the relevant passages to get the solver to work. Please let me know if these solutions need improvement or are wrong.