### PR TITLE
Getting access modifiers

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -308,7 +308,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
 
     @Override
     public AccessLevel accessLevel() {
-        throw new UnsupportedOperationException();
+        return Helper.toAccessLevel(wrappedNode.getModifiers());
     }
 
     ///

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserConstructorDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserConstructorDeclaration.java
@@ -63,7 +63,7 @@ public class JavaParserConstructorDeclaration implements ConstructorDeclaration 
 
     @Override
     public AccessLevel accessLevel() {
-        throw new UnsupportedOperationException();
+        return Helper.toAccessLevel(wrapped.getModifiers());
     }
 
     @Override

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -297,7 +297,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration implement
 
         @Override
         public AccessLevel accessLevel() {
-            throw new UnsupportedOperationException();
+            return Helper.toAccessLevel(enumDeclaration.getWrappedNode().getModifiers());
         }
     }
 

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -250,7 +250,7 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration impl
 
     @Override
     public AccessLevel accessLevel() {
-        throw new UnsupportedOperationException();
+        return Helper.toAccessLevel(wrappedNode.getModifiers());
     }
 
     ///

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
@@ -146,6 +146,6 @@ public class JavaParserMethodDeclaration implements MethodDeclaration {
 
     @Override
     public AccessLevel accessLevel() {
-        throw new UnsupportedOperationException();
+        return Helper.toAccessLevel(wrappedNode.getModifiers());
     }
 }


### PR DESCRIPTION
I was working with a `JavaParserClassDeclaration` object when i saw that i couldn't get access modifier from this object. It can be obtained from JavaParser, but you probably created this method to wrap that ?

`JavaParserFieldDeclaration` already has this `accessLevel()` returning the access specifier. I just updated the method in `JavaParserClassDeclaration`, `JavaParserConstructorDeclaration`, `JavaParserEnumDeclaration`, `JavaParserInterfaceDeclaration`, `JavaParserMethodDeclaration`.