### PR TITLE
Type system changes

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -370,8 +370,13 @@ public class TypeExtractor extends DefaultVisitorAdapter {
                         ExpressionStmt expressionStmt = (ExpressionStmt) lambdaExpr.getBody();
                         Type actualType = facade.getType(expressionStmt.getExpression());
                         Type formalType = functionalMethod.get().returnType();
-                        inferenceContext.addPair(formalType, actualType);
-                        result = inferenceContext.resolve(inferenceContext.addSingle(result));
+
+                        // if the functional method returns void anyway
+                        // we don't need to bother inferring types
+                        if (!(formalType instanceof VoidType)){
+                            inferenceContext.addPair(formalType, actualType);
+                            result = inferenceContext.resolve(inferenceContext.addSingle(result));
+                        }
                     } else {
                         throw new UnsupportedOperationException();
                     }
@@ -398,7 +403,8 @@ public class TypeExtractor extends DefaultVisitorAdapter {
             logger.finest("getType on method reference expr " + refMethod.getCorrespondingDeclaration().getName());
             //logger.finest("Method param " + refMethod.getCorrespondingDeclaration().getParam(pos));
             if (solveLambdas) {
-                Type result = refMethod.getCorrespondingDeclaration().getParam(pos).getType();
+                MethodUsage usage = facade.solveMethodAsUsage(callExpr);
+                Type result = usage.getParamType(pos);
                 // We need to replace the type variables
                 Context ctx = JavaParserFactory.getContext(node, typeSolver);
                 result = facade.solveGenericTypes(result, ctx, typeSolver);

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
@@ -214,7 +214,7 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
                     String importString = importDecl.getNameAsString();
 
                     com.github.javaparser.symbolsolver.model.declarations.TypeDeclaration ref = typeSolver.solveType(importString);
-                    SymbolReference<MethodDeclaration> method = MethodResolutionLogic.solveMethodInType(ref, name, argumentsTypes, typeSolver, true);
+                    SymbolReference<MethodDeclaration> method = MethodResolutionLogic.solveMethodInType(ref, name, argumentsTypes, true, typeSolver);
 
                     if (method.isSolved()) {
                         return method;
@@ -225,7 +225,7 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
                     if (qName.equals(name) || qName.endsWith("." + name)) {
                         String typeName = getType(qName);
                         com.github.javaparser.symbolsolver.model.declarations.TypeDeclaration ref = typeSolver.solveType(typeName);
-                        SymbolReference<MethodDeclaration> method = MethodResolutionLogic.solveMethodInType(ref, name, argumentsTypes, typeSolver, true);
+                        SymbolReference<MethodDeclaration> method = MethodResolutionLogic.solveMethodInType(ref, name, argumentsTypes, true, typeSolver);
                         if (method.isSolved()) {
                             return method;
                         }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -88,7 +88,7 @@ public class JavaParserTypeDeclarationAdapter {
         if (!Object.class.getCanonicalName().equals(typeDeclaration.getQualifiedName())) {
             for (ReferenceType ancestor : typeDeclaration.getAncestors()) {
                 SymbolReference<MethodDeclaration> res = MethodResolutionLogic
-                        .solveMethodInType(ancestor.getTypeDeclaration(), name, argumentsTypes, typeSolver, staticOnly);
+                        .solveMethodInType(ancestor.getTypeDeclaration(), name, argumentsTypes, staticOnly, typeSolver);
                 // consider methods from superclasses and only default methods from interfaces :
                 // not true, we should keep abstract as a valid candidate
                 // abstract are removed in MethodResolutionLogic.isApplicable is necessary
@@ -108,7 +108,7 @@ public class JavaParserTypeDeclarationAdapter {
 
         // if is interface and candidate method list is empty, we should check the Object Methods
         if (candidateMethods.isEmpty() && typeDeclaration.isInterface()) {
-            SymbolReference<MethodDeclaration> res = MethodResolutionLogic.solveMethodInType(new ReflectionClassDeclaration(Object.class, typeSolver), name, argumentsTypes, typeSolver, false);
+            SymbolReference<MethodDeclaration> res = MethodResolutionLogic.solveMethodInType(new ReflectionClassDeclaration(Object.class, typeSolver), name, argumentsTypes, false, typeSolver);
             if (res.isSolved()) {
                 candidateMethods.add(res.getCorrespondingDeclaration());
             }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
@@ -32,6 +32,7 @@ import com.github.javaparser.symbolsolver.model.methods.MethodUsage;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.resolution.Value;
+import com.github.javaparser.symbolsolver.model.typesystem.LambdaConstraintType;
 import com.github.javaparser.symbolsolver.model.typesystem.Type;
 import com.github.javaparser.symbolsolver.resolution.SymbolDeclarator;
 import javaslang.Tuple2;
@@ -64,7 +65,14 @@ public class LambdaExprContext extends AbstractJavaParserContext<LambdaExpr> {
                         MethodUsage methodUsage = JavaParserFacade.get(typeSolver).solveMethodAsUsage(methodCallExpr);
                         int i = pos(methodCallExpr, wrappedNode);
                         Type lambdaType = methodUsage.getParamTypes().get(i);
-                        Value value = new Value(lambdaType.asReferenceType().typeParametersValues().get(0), name);
+                        Type argType = lambdaType.asReferenceType().typeParametersValues().get(0);
+                        LambdaConstraintType conType;
+                        if (argType.isWildcard()){
+                            conType = LambdaConstraintType.bound(argType.asWildcard().getBoundedType());
+                        } else {
+                            conType = LambdaConstraintType.bound(argType);
+                        }
+                        Value value = new Value(conType, name);
                         return Optional.of(value);
                     } else if (getParentNode(wrappedNode) instanceof VariableDeclarator) {
                         VariableDeclarator variableDeclarator = (VariableDeclarator) getParentNode(wrappedNode);

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeImpl.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeImpl.java
@@ -111,6 +111,8 @@ public class ReferenceTypeImpl extends ReferenceType {
         } else if (other.isTypeVariable()) {
             // TODO look bounds...
             return true;
+        } else if (other.isConstraint()){
+            return isAssignableBy(other.asConstraintType().getBound());
         } else if (other.isWildcard()) {
             if (this.getQualifiedName().equals(Object.class.getCanonicalName())) {
                 return true;

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -124,13 +124,13 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration {
         }
         if (getSuperClass() != null) {
             ClassDeclaration superClass = (ClassDeclaration) getSuperClass().getTypeDeclaration();
-            SymbolReference<MethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(superClass, name, argumentsTypes, typeSolver, false);
+            SymbolReference<MethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(superClass, name, argumentsTypes, staticOnly, typeSolver);
             if (ref.isSolved()) {
                 methods.add(ref.getCorrespondingDeclaration());
             }
         }
         for (ReferenceType interfaceDeclaration : getInterfaces()) {
-            SymbolReference<MethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(interfaceDeclaration.getTypeDeclaration(), name, argumentsTypes, typeSolver, false);
+            SymbolReference<MethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(interfaceDeclaration.getTypeDeclaration(), name, argumentsTypes, staticOnly, typeSolver);
             if (ref.isSolved()) {
                 methods.add(ref.getCorrespondingDeclaration());
             }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
@@ -135,14 +135,8 @@ public class ReflectionEnumDeclaration extends AbstractTypeDeclaration implement
   }
 
   public SymbolReference<MethodDeclaration> solveMethod(String name, List<Type> parameterTypes, boolean staticOnly) {
-    List<MethodDeclaration> methods = new ArrayList<>();
-    Predicate<Method> staticOnlyCheck = m -> !staticOnly || (staticOnly && Modifier.isStatic(m.getModifiers()));
-    for (Method method : clazz.getMethods()) {
-      if (method.isBridge() || method.isSynthetic() || !method.getName().equals(name)|| !staticOnlyCheck.test(method)) continue;
-      MethodDeclaration methodDeclaration = new ReflectionMethodDeclaration(method, typeSolver);
-      methods.add(methodDeclaration);
-    }
-    return MethodResolutionLogic.findMostApplicable(methods, name, parameterTypes, typeSolver);
+    return ReflectionMethodResolutionLogic.solveMethod(name, parameterTypes, staticOnly,
+            typeSolver,this, clazz);
   }
 
   public Optional<MethodUsage> solveMethodAsUsage(String name, List<Type> parameterTypes, TypeSolver typeSolver, Context invokationContext, List<Type> typeParameterValues) {

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -89,12 +89,27 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration impl
             MethodDeclaration methodDeclaration = new ReflectionMethodDeclaration(method, typeSolver);
             methods.add(methodDeclaration);
         }
+
+        for (ReferenceType ancestor : getAncestors()) {
+            SymbolReference<MethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(ancestor.getTypeDeclaration(), name, parameterTypes, staticOnly, typeSolver);
+            if (ref.isSolved()) {
+                methods.add(ref.getCorrespondingDeclaration());
+            }
+        }
+
+        if (getAncestors().isEmpty()){
+            ReferenceTypeImpl objectClass = new ReferenceTypeImpl(new ReflectionClassDeclaration(Object.class, typeSolver), typeSolver);
+            SymbolReference<MethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(objectClass.getTypeDeclaration(), name, parameterTypes, staticOnly, typeSolver);
+            if (ref.isSolved()) {
+                methods.add(ref.getCorrespondingDeclaration());
+            }
+        }
         return MethodResolutionLogic.findMostApplicable(methods, name, parameterTypes, typeSolver);
     }
 
     @Override
     public String toString() {
-        return "ReflectionClassDeclaration{" +
+        return "ReflectionInterfaceDeclaration{" +
                 "clazz=" + clazz.getCanonicalName() +
                 '}';
     }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -82,29 +82,8 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration impl
 
     @Deprecated
     public SymbolReference<MethodDeclaration> solveMethod(String name, List<Type> parameterTypes, boolean staticOnly) {
-        List<MethodDeclaration> methods = new ArrayList<>();
-        Predicate<Method> staticOnlyCheck = m -> !staticOnly || (staticOnly && Modifier.isStatic(m.getModifiers()));
-        for (Method method : clazz.getMethods()) {
-            if (method.isBridge() || method.isSynthetic() || !method.getName().equals(name)|| !staticOnlyCheck.test(method)) continue;
-            MethodDeclaration methodDeclaration = new ReflectionMethodDeclaration(method, typeSolver);
-            methods.add(methodDeclaration);
-        }
-
-        for (ReferenceType ancestor : getAncestors()) {
-            SymbolReference<MethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(ancestor.getTypeDeclaration(), name, parameterTypes, staticOnly, typeSolver);
-            if (ref.isSolved()) {
-                methods.add(ref.getCorrespondingDeclaration());
-            }
-        }
-
-        if (getAncestors().isEmpty()){
-            ReferenceTypeImpl objectClass = new ReferenceTypeImpl(new ReflectionClassDeclaration(Object.class, typeSolver), typeSolver);
-            SymbolReference<MethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(objectClass.getTypeDeclaration(), name, parameterTypes, staticOnly, typeSolver);
-            if (ref.isSolved()) {
-                methods.add(ref.getCorrespondingDeclaration());
-            }
-        }
-        return MethodResolutionLogic.findMostApplicable(methods, name, parameterTypes, typeSolver);
+        return ReflectionMethodResolutionLogic.solveMethod(name, parameterTypes, staticOnly,
+                typeSolver,this, clazz);
     }
 
     @Override

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/logic/InferenceContextTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/logic/InferenceContextTest.java
@@ -54,6 +54,8 @@ public class InferenceContextTest {
         object = new ReferenceTypeImpl(new ReflectionClassDeclaration(Object.class, typeSolver), typeSolver);
         listOfString = listOf(string);
         tpE = EasyMock.createMock(TypeParameterDeclaration.class);
+        EasyMock.expect(tpE.getName()).andReturn("T").anyTimes();
+        EasyMock.replay(tpE);
         listOfE = listOf(new TypeVariable(tpE));
     }
 

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
@@ -584,7 +584,7 @@ public class ReferenceTypeTest {
         ReferenceType stream = new ReferenceTypeImpl(streamInterface, typeResolver);
 
         com.github.javaparser.symbolsolver.model.declarations.MethodDeclaration streamMap = streamInterface.getDeclaredMethods().stream().filter(m -> m.getName().equals("map")).findFirst().get();
-        TypeParameterDeclaration streamMapR = streamMap.findTypeParameter("R").get();
+        TypeParameterDeclaration streamMapR = streamMap.findTypeParameter("T").get();
         TypeVariable typeVariable = new TypeVariable(streamMapR);
         stream = stream.deriveTypeParameters(stream.typeParametersMap().toBuilder().setValue(stream.typeDeclaration.getTypeParameters().get(0), typeVariable).build());
 

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/LambdaConstraintType.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/LambdaConstraintType.java
@@ -1,0 +1,37 @@
+package com.github.javaparser.symbolsolver.model.typesystem;
+
+public class LambdaConstraintType  implements Type {
+    Type bound;
+
+    public LambdaConstraintType(Type bound) {
+        this.bound = bound;
+    }
+
+    @Override
+    public String describe() {
+        return "? super " + bound.describe();
+    }
+
+    public Type getBound() {
+        return bound;
+    }
+
+    @Override
+    public boolean isConstraint() {
+        return true;
+    }
+
+    @Override
+    public LambdaConstraintType asConstraintType() {
+        return this;
+    }
+
+    public static LambdaConstraintType bound(Type bound){
+        return new LambdaConstraintType(bound);
+    }
+
+    @Override
+    public boolean isAssignableBy(Type other) {
+        return bound.isAssignableBy(other);
+    }
+}

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceType.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceType.java
@@ -172,12 +172,12 @@ public abstract class ReferenceType implements Type, TypeParametrized, TypeParam
             throw new IllegalArgumentException();
         }
 
-        Type result = this;
+        ReferenceType result = this;
         int i = 0;
         for (Type tp : this.typeParametersValues()) {
             Type transformedTp = tp.replaceTypeVariables(tpToReplace, replaced, inferredTypes);
             // Identity comparison on purpose
-            if (tp.isTypeVariable()) {
+            if (tp.isTypeVariable() && tp.asTypeVariable().describe().equals(tpToReplace.getName())) {
                 inferredTypes.put(tp.asTypeParameter(), replaced);
             }
             if (true) {
@@ -188,15 +188,14 @@ public abstract class ReferenceType implements Type, TypeParametrized, TypeParam
             i++;
         }
 
-        if (result.isReferenceType() && result.asReferenceType().typeDeclaration.getTypeParameters().contains(tpToReplace)) {
-            List<Type> values = result.asReferenceType().typeParametersValues();
-            int index = result.asReferenceType().typeDeclaration.getTypeParameters().indexOf(tpToReplace);
-            // this is necessary to avoid an issue in which a type like List<String> becomes List<List<String>>
-            if (!(replaced.isReferenceType() && this.getQualifiedName().equals(replaced.asReferenceType().getQualifiedName()))) {
-                values.set(index, replaced);
-            }
-            return create(result.asReferenceType().getTypeDeclaration(), values, typeSolver);
+        List<Type> values = result.typeParametersValues();
+        if(values.contains(tpToReplace)){
+            int index = values.indexOf(tpToReplace);
+            values.set(index, replaced);
+            return create(result.getTypeDeclaration(), values, typeSolver);
         }
+
+
         return result;
     }
 

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/Type.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/Type.java
@@ -74,6 +74,11 @@ public interface Type {
     }
 
     /**
+     * Is this a lambda constraint type?
+     */
+    default boolean isConstraint() { return false; }
+
+    /**
      * Can this be seen as a ReferenceTypeUsage?
      * In other words: is this a reference to a class, an interface or an enum?
      */
@@ -119,6 +124,10 @@ public interface Type {
 
     default Wildcard asWildcard() {
         throw new UnsupportedOperationException(String.format("%s is not a Wildcard", this));
+    }
+
+    default LambdaConstraintType asConstraintType() {
+        throw new UnsupportedOperationException(String.format("%s is not a constraint type", this));
     }
 
     ///

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/TypeVariable.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/TypeVariable.java
@@ -74,7 +74,8 @@ public class TypeVariable implements Type {
 
     @Override
     public Type replaceTypeVariables(TypeParameterDeclaration tpToBeReplaced, Type replaced, Map<TypeParameterDeclaration, Type> inferredTypes) {
-        if (tpToBeReplaced.getQualifiedName().equals(typeParameter.getQualifiedName())) {
+        if(tpToBeReplaced.getName().equals(this.typeParameter.getName())){
+            inferredTypes.put(this.asTypeParameter(), replaced);
             return replaced;
         } else {
             return this;
@@ -111,7 +112,7 @@ public class TypeVariable implements Type {
         if (other.isTypeVariable()) {
             return describe().equals(other.describe());
         } else {
-            return false;
+            return true;
         }
     }
 


### PR DESCRIPTION
PR for the issues we were discussing before plus some other fixes I was working on for generic types.

Among others this fixes:

1. The substitution of type variables wasn't being performed properly so for example:

```java
List<String> list;
list.stream().map(x -> x.codePoints()); // resolved as Stream<String> incorrectly, should be Stream<IntStream>
```

2. Issues with reflection interfaces only resolving methods in the current interface
```java
List<String> list;
list.toString(); // error - can't be resolved
```

3. Some issues when selecting variadic vs non-variadic in most specific method selection
4. Some general issues with type inference
