### PR TITLE
Fix issues with lambdas

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -356,7 +356,7 @@ public class TypeExtractor extends DefaultVisitorAdapter {
                 //lambdas
                 Optional<MethodUsage> functionalMethod = FunctionalInterfaceLogic.getFunctionalMethod(result);
                 if (functionalMethod.isPresent()) {
-                    LambdaExpr lambdaExpr = (LambdaExpr) node;
+                    LambdaExpr lambdaExpr = node;
 
                     InferenceContext inferenceContext = new InferenceContext(MyObjectProvider.INSTANCE);
                     // At this point parameterType

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
@@ -81,11 +81,11 @@ public class LambdaExprContext extends AbstractJavaParserContext<LambdaExpr> {
                             int lambdaParamIndex;
                             for (lambdaParamIndex = 0; lambdaParamIndex < wrappedNode.getParameters().size(); lambdaParamIndex++){
                                 if (wrappedNode.getParameter(lambdaParamIndex).getName().getIdentifier().equals(name)){
-                                    found =true;
+                                    found = true;
                                     break;
                                 }
                             }
-                            if (!found) return Optional.empty();
+                            if (!found) { return Optional.empty(); }
 
                             // Now resolve the argument type using the inference context
                             Type argType = inferenceContext.resolve(inferenceContext.addSingle(functionalMethod.getParamType(lambdaParamIndex)));

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
@@ -74,6 +74,32 @@ public class LambdaResolutionTest extends AbstractResolutionTest {
     }
 
     @Test
+    public void lambdaReduce() throws ParseException {
+        CompilationUnit cu = parseSample("Lambda");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Agenda");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "reduce");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        Expression expr = returnStmt.getExpression().get();
+
+        JavaParserFacade javaParserFacade = JavaParserFacade.get(new ReflectionTypeSolver());
+        Type type1 = javaParserFacade.getType(expr);
+        assertEquals("java.util.Optional<java.lang.Integer>", type1.describe());
+    }
+
+    @Test
+    public void lambdaBifunc() throws ParseException {
+        CompilationUnit cu = parseSample("Lambda");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Agenda");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "bifunc");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        Expression expr = returnStmt.getExpression().get();
+
+        JavaParserFacade javaParserFacade = JavaParserFacade.get(new ReflectionTypeSolver());
+        Type type1 = javaParserFacade.getType(expr);
+        assertEquals("double", type1.describe());
+    }
+
+    @Test
     public void lambdaCollectParam() throws ParseException {
         CompilationUnit cu = parseSample("LambdaCollect");
         com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Agenda");
@@ -100,6 +126,8 @@ public class LambdaResolutionTest extends AbstractResolutionTest {
         Type type = javaParserFacade.getType(expression);
         assertEquals("java.util.List<java.lang.String>", type.describe());
     }
+
+
 
 
 }

--- a/java-symbol-solver-core/src/test/resources/Lambda.java.txt
+++ b/java-symbol-solver-core/src/test/resources/Lambda.java.txt
@@ -1,4 +1,5 @@
 import java.util.List;
+import java.util.function.BiFunction;
 
 @FunctionalInterface
 public interface Lambda {
@@ -13,6 +14,27 @@ public class Agenda {
 
     public void lambdaMap(String personName) {
         return persons.stream().map(p -> p.toLowerCase());
+    }
+
+    public void lambdaMap2(){
+        return persons.stream().map(p -> p.codePoints());
+    }
+
+    public void reduce(){
+        List<Integer> a;
+        return a.stream().reduce((x,y) -> x * y);
+    }
+
+    double test(BiFunction<Integer,List,String> func){
+        return 0;
+    }
+
+    public double bifunc(){
+        return test((x,y) -> String.valueOf(func(x,y)));
+    }
+
+    int func(int a, List b){
+        return 1;
     }
 
     public void testFunctionalVar() {

--- a/java-symbol-solver-logic/src/main/java/com/github/javaparser/symbolsolver/logic/InferenceContext.java
+++ b/java-symbol-solver-logic/src/main/java/com/github/javaparser/symbolsolver/logic/InferenceContext.java
@@ -75,9 +75,9 @@ public class InferenceContext {
                 final String formalParamTypeQName = formalTypeAsReference.getQualifiedName();
                 List<Type> correspondingFormalType = ancestors.stream().filter((a) -> a.getQualifiedName().equals(formalParamTypeQName)).collect(Collectors.toList());
                 if (correspondingFormalType.isEmpty()) {
-                    List<ReferenceType> ancestors2 = formalTypeAsReference.getAllAncestors();
+                    ancestors = formalTypeAsReference.getAllAncestors();
                     final String actualParamTypeQname = actualTypeAsReference.getQualifiedName();
-                    List<Type> correspondingActualType = ancestors2.stream().filter(a -> a.getQualifiedName().equals(actualParamTypeQname)).collect(Collectors.toList());
+                    List<Type> correspondingActualType = ancestors.stream().filter(a -> a.getQualifiedName().equals(actualParamTypeQname)).collect(Collectors.toList());
                     if (correspondingActualType.isEmpty()){
                         throw new ConfilictingGenericTypesException(formalType, actualType);
                     }

--- a/java-symbol-solver-logic/src/main/java/com/github/javaparser/symbolsolver/logic/InferenceContext.java
+++ b/java-symbol-solver-logic/src/main/java/com/github/javaparser/symbolsolver/logic/InferenceContext.java
@@ -75,7 +75,14 @@ public class InferenceContext {
                 final String formalParamTypeQName = formalTypeAsReference.getQualifiedName();
                 List<Type> correspondingFormalType = ancestors.stream().filter((a) -> a.getQualifiedName().equals(formalParamTypeQName)).collect(Collectors.toList());
                 if (correspondingFormalType.isEmpty()) {
-                    throw new ConfilictingGenericTypesException(formalType, actualType);
+                    List<ReferenceType> ancestors2 = formalTypeAsReference.getAllAncestors();
+                    final String actualParamTypeQname = actualTypeAsReference.getQualifiedName();
+                    List<Type> correspondingActualType = ancestors2.stream().filter(a -> a.getQualifiedName().equals(actualParamTypeQname)).collect(Collectors.toList());
+                    if (correspondingActualType.isEmpty()){
+                        throw new ConfilictingGenericTypesException(formalType, actualType);
+                    }
+                    correspondingFormalType = correspondingActualType;
+
                 }
                 actualTypeAsReference = correspondingFormalType.get(0).asReferenceType();
             }
@@ -96,7 +103,7 @@ public class InferenceContext {
         } else if (formalType instanceof InferenceVariableType) {
             ((InferenceVariableType) formalType).registerEquivalentType(actualType);
             if (actualType instanceof InferenceVariableType) {
-                ((InferenceVariableType)actualType).registerEquivalentType(formalType);
+                ((InferenceVariableType) actualType).registerEquivalentType(formalType);
             }
         } else if (actualType.isNull()) {
             // nothing to do
@@ -112,16 +119,22 @@ public class InferenceContext {
                     ((InferenceVariableType) formalType.asWildcard().getBoundedType()).registerEquivalentType(actualType);
                 }
             }
-            if (actualType.isWildcard()){
+            if (actualType.isWildcard()) {
                 Wildcard formalWildcard = formalType.asWildcard();
                 Wildcard actualWildcard = actualType.asWildcard();
-                if(formalWildcard.isBounded() && formalWildcard.getBoundedType() instanceof InferenceVariableType){
-                    if (formalWildcard.isSuper() && actualWildcard.isSuper()){
+                if (formalWildcard.isBounded() && formalWildcard.getBoundedType() instanceof InferenceVariableType) {
+                    if (formalWildcard.isSuper() && actualWildcard.isSuper()) {
                         ((InferenceVariableType) formalType.asWildcard().getBoundedType()).registerEquivalentType(actualWildcard.getBoundedType());
-                    } else if (formalWildcard.isExtends() && actualWildcard.isExtends()){
+                    } else if (formalWildcard.isExtends() && actualWildcard.isExtends()) {
                         ((InferenceVariableType) formalType.asWildcard().getBoundedType()).registerEquivalentType(actualWildcard.getBoundedType());
                     }
                 }
+            }
+        } else if (actualType instanceof InferenceVariableType){
+            if (formalType instanceof ReferenceType){
+                ((InferenceVariableType) actualType).registerEquivalentType(formalType);
+            } else if (formalType instanceof InferenceVariableType){
+                ((InferenceVariableType) actualType).registerEquivalentType(formalType);
             }
         } else if (actualType.isConstraint()){
             LambdaConstraintType constraintType = actualType.asConstraintType();

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/PrimitiveType.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/PrimitiveType.java
@@ -113,6 +113,8 @@ public class PrimitiveType implements Type {
                 }
             }
             return false;
+        } else if (other.isConstraint()){
+            return this.isAssignableBy(other.asConstraintType().getBound());
         } else {
             return false;
         }

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/parametrization/TypeParametersMap.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/parametrization/TypeParametersMap.java
@@ -20,9 +20,7 @@ import com.github.javaparser.symbolsolver.model.declarations.TypeParameterDeclar
 import com.github.javaparser.symbolsolver.model.typesystem.Type;
 import com.github.javaparser.symbolsolver.model.typesystem.TypeVariable;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * A map of values associated to TypeParameters.
@@ -111,6 +109,14 @@ public class TypeParametersMap {
         } else {
             return Optional.empty();
         }
+    }
+
+    public List<String> getNames(){
+        return new ArrayList<>(nameToValue.keySet());
+    }
+
+    public List<Type> getTypes(){
+        return new ArrayList<>(nameToValue.values());
     }
 
     public Builder toBuilder() {


### PR DESCRIPTION
Hello again,

This fixes a few issues with resolving lambda arguments. The implicit type of a lambda parameter used to be guessed based on the first generic argument of the functional interface (completely ignoring bifunctions or out-of-expected order ones). See 1016f42321316f6b6bd0e7f4cb51ee5958e01153 for more details.