### PR TITLE
Ignore UnsupportedOperationException when solving type in a type's ancestor

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -69,11 +69,16 @@ public class JavaParserTypeDeclarationAdapter {
 
         // Look into extended classes and implemented interfaces
         for (ReferenceType ancestor : this.typeDeclaration.getAncestors()) {
-            for (TypeDeclaration internalTypeDeclaration : ancestor.getTypeDeclaration().internalTypes()) {
-                if (internalTypeDeclaration.getName().equals(name)) {
-                    return SymbolReference.solved(internalTypeDeclaration);
-                }
+        	try {
+	            for (TypeDeclaration internalTypeDeclaration : ancestor.getTypeDeclaration().internalTypes()) {
+	                if (internalTypeDeclaration.getName().equals(name)) {
+	                    return SymbolReference.solved(internalTypeDeclaration);
+	                }
+	            }
+        	} catch (UnsupportedOperationException e) {
+	            // just continue using the next ancestor
             }
+        	
         }
 
         return context.getParent().solveType(name, typeSolver);


### PR DESCRIPTION
For example: This exception is thrown by `internalTypes()` when an ancestor is a JavassistClassDeclaration.