### PR TITLE
Issue 190: Access package and class names separately in type declaration

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/Helper.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/Helper.java
@@ -73,6 +73,14 @@ class Helper {
             } else {
                 return b + "." + cn;
             }
+        } else if (container instanceof com.github.javaparser.ast.body.EnumDeclaration) {
+            String b = getClassName(base, getParentNode(container));
+            String cn = ((com.github.javaparser.ast.body.EnumDeclaration) container).getName().getId();
+            if (b.isEmpty()) {
+                return cn;
+            } else {
+                return b + "." + cn;
+            }
         } else if (container != null) {
             return getClassName(base, getParentNode(container));
         }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/Helper.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/Helper.java
@@ -44,31 +44,38 @@ class Helper {
         }
     }
 
-    public static String containerName(String base, Node container) {
+    static String containerName(Node container) {
+        String packageName = getPackageName(container);
+        String className = getClassName("", container);
+        return packageName +
+                ((!packageName.isEmpty() && !className.isEmpty()) ? "." : "") +
+                className;
+    }
+
+    static String getPackageName(Node container) {
+        if (container instanceof CompilationUnit) {
+            Optional<PackageDeclaration> p = ((CompilationUnit) container).getPackageDeclaration();
+            if (p.isPresent()) {
+                return p.get().getName().toString();
+            }
+        } else if (container != null) {
+            return getPackageName(getParentNode(container));
+        }
+        return "";
+    }
+
+    static String getClassName(String base, Node container) {
         if (container instanceof com.github.javaparser.ast.body.ClassOrInterfaceDeclaration) {
-            String b = containerName(base, getParentNode(container));
+            String b = getClassName(base, getParentNode(container));
             String cn = ((com.github.javaparser.ast.body.ClassOrInterfaceDeclaration) container).getName().getId();
             if (b.isEmpty()) {
                 return cn;
             } else {
                 return b + "." + cn;
             }
-        } else if (container instanceof CompilationUnit) {
-            Optional<PackageDeclaration> p = ((CompilationUnit) container).getPackageDeclaration();
-            if (p.isPresent()) {
-                String b = p.get().getName().toString();
-                if (base.isEmpty()) {
-                    return b;
-                } else {
-                    return b + "." + base;
-                }
-            } else {
-                return base;
-            }
         } else if (container != null) {
-            return containerName(base, getParentNode(container));
-        } else {
-            return base;
+            return getClassName(base, getParentNode(container));
         }
+        return base;
     }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
@@ -55,6 +55,16 @@ public class JavaParserAnnotationDeclaration extends AbstractTypeDeclaration imp
     }
 
     @Override
+    public String getPackageName() {
+        return Helper.getPackageName(wrappedNode);
+    }
+
+    @Override
+    public String getClassName() {
+        return Helper.getClassName("", wrappedNode);
+    }
+
+    @Override
     public String getQualifiedName() {
         String containerName = Helper.containerName(getParentNode(wrappedNode));
         if (containerName.isEmpty()) {

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
@@ -56,7 +56,7 @@ public class JavaParserAnnotationDeclaration extends AbstractTypeDeclaration imp
 
     @Override
     public String getQualifiedName() {
-        String containerName = Helper.containerName("", getParentNode(wrappedNode));
+        String containerName = Helper.containerName(getParentNode(wrappedNode));
         if (containerName.isEmpty()) {
             return wrappedNode.getName().getId();
         } else {

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -200,6 +200,16 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
     }
 
     @Override
+    public String getPackageName() {
+        return javaParserTypeAdapter.getPackageName();
+    }
+
+    @Override
+    public String getClassName() {
+        return javaParserTypeAdapter.getClassName();
+    }
+
+    @Override
     public String getQualifiedName() {
         return javaParserTypeAdapter.getQualifiedName();
     }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -136,6 +136,16 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration implement
     }
 
     @Override
+    public String getPackageName() {
+        return javaParserTypeAdapter.getPackageName();
+    }
+
+    @Override
+    public String getClassName() {
+        return javaParserTypeAdapter.getClassName();
+    }
+
+    @Override
     public String getQualifiedName() {
         return javaParserTypeAdapter.getQualifiedName();
     }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -129,6 +129,16 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration impl
     }
 
     @Override
+    public String getPackageName() {
+        return javaParserTypeAdapter.getPackageName();
+    }
+
+    @Override
+    public String getClassName() {
+        return javaParserTypeAdapter.getClassName();
+    }
+
+    @Override
     public String getQualifiedName() {
         return javaParserTypeAdapter.getQualifiedName();
     }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeAdapter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeAdapter.java
@@ -33,8 +33,16 @@ public class JavaParserTypeAdapter<T extends Node & NodeWithSimpleName<T> & Node
         this.typeSolver = typeSolver;
     }
 
+    public String getPackageName() {
+        return Helper.getPackageName(wrappedNode);
+    }
+
+    public String getClassName() {
+        return Helper.getClassName("", wrappedNode);
+    }
+
     public String getQualifiedName() {
-        String containerName = Helper.containerName("", getParentNode(wrappedNode));
+        String containerName = Helper.containerName(getParentNode(wrappedNode));
         if (containerName.isEmpty()) {
             return wrappedNode.getName().getId();
         } else {

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeVariableDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeVariableDeclaration.java
@@ -54,6 +54,16 @@ public class JavaParserTypeVariableDeclaration extends AbstractTypeDeclaration {
     }
 
     @Override
+    public String getPackageName() {
+        return Helper.getPackageName(wrappedNode);
+    }
+
+    @Override
+    public String getClassName() {
+        return Helper.getClassName("", wrappedNode);
+    }
+
+    @Override
     public String getQualifiedName() {
         return getName();
     }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -101,6 +101,20 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration {
     }
 
     @Override
+    public String getPackageName() {
+        return ctClass.getPackageName();
+    }
+
+    @Override
+    public String getClassName() {
+        String className = ctClass.getName().replace('$', '.');
+        if (getPackageName() != null) {
+            return className.substring(getPackageName().length() + 1, className.length());
+        }
+        return className;
+    }
+
+    @Override
     public String getQualifiedName() {
         return ctClass.getName().replace('$', '.');
     }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -65,8 +65,22 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration implements
     }
 
     @Override
+    public String getPackageName() {
+        return ctClass.getPackageName();
+    }
+
+    @Override
+    public String getClassName() {
+        String name = ctClass.getName().replace('$', '.');
+        if (getPackageName() != null) {
+            return name.substring(getPackageName().length() + 1, name.length());
+        }
+        return name;
+    }
+
+    @Override
     public String getQualifiedName() {
-        return ctClass.getName();
+        return ctClass.getName().replace('$', '.');
     }
 
     @Override

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -77,8 +77,22 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration imple
     }
 
     @Override
+    public String getPackageName() {
+        return ctClass.getPackageName();
+    }
+
+    @Override
+    public String getClassName() {
+        String className = ctClass.getName().replace('$', '.');
+        if (getPackageName() != null) {
+            return className.substring(getPackageName().length() + 1, className.length());
+        }
+        return className;
+    }
+
+    @Override
     public String getQualifiedName() {
-        return ctClass.getName();
+        return ctClass.getName().replace('$', '.');
     }
 
     @Deprecated

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -107,6 +107,24 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration {
         return clazz.hashCode();
     }
 
+
+    @Override
+    public String getPackageName() {
+        if (clazz.getPackage() != null) {
+            return clazz.getPackage().getName();
+        }
+        return null;
+    }
+
+    @Override
+    public String getClassName() {
+        String canonicalName = clazz.getCanonicalName();
+        if (canonicalName != null && getPackageName() != null) {
+            return canonicalName.substring(getPackageName().length() + 1, canonicalName.length());
+        }
+        return null;
+    }
+
     @Override
     public String getQualifiedName() {
         return clazz.getCanonicalName();

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
@@ -80,6 +80,23 @@ public class ReflectionEnumDeclaration extends AbstractTypeDeclaration implement
   }
 
   @Override
+  public String getPackageName() {
+    if (clazz.getPackage() != null) {
+      return clazz.getPackage().getName();
+    }
+    return null;
+  }
+
+  @Override
+  public String getClassName() {
+    String canonicalName = clazz.getCanonicalName();
+    if (canonicalName != null && getPackageName() != null) {
+      return canonicalName.substring(getPackageName().length() + 1, canonicalName.length());
+    }
+    return null;
+  }
+
+  @Override
   public String getQualifiedName() {
     return clazz.getCanonicalName();
   }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -76,6 +76,23 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration impl
     }
 
     @Override
+    public String getPackageName() {
+        if (clazz.getPackage() != null) {
+            return clazz.getPackage().getName();
+        }
+        return null;
+    }
+
+    @Override
+    public String getClassName() {
+        String canonicalName = clazz.getCanonicalName();
+        if (canonicalName != null && getPackageName() != null) {
+            return canonicalName.substring(getPackageName().length() + 1, canonicalName.length());
+        }
+        return null;
+    }
+
+    @Override
     public String getQualifiedName() {
         return clazz.getCanonicalName();
     }

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
@@ -138,6 +138,18 @@ public class JavaParserClassDeclarationTest extends AbstractTest {
     }
 
     @Test
+    public void testGetPackageName() {
+        JavaParserClassDeclaration compilationUnit = (JavaParserClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+        assertEquals("com.github.javaparser.ast", compilationUnit.getPackageName());
+    }
+
+    @Test
+    public void testGetClassName() {
+        JavaParserClassDeclaration compilationUnit = (JavaParserClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+        assertEquals("CompilationUnit", compilationUnit.getClassName());
+    }
+
+    @Test
     public void testGetQualifiedName() {
         JavaParserClassDeclaration compilationUnit = (JavaParserClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
         assertEquals("com.github.javaparser.ast.CompilationUnit", compilationUnit.getQualifiedName());

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
@@ -101,6 +101,18 @@ public class JavaParserEnumDeclarationTest extends AbstractTest {
     }
 
     @Test
+    public void testGetPackageName() {
+        JavaParserEnumDeclaration modifier = (JavaParserEnumDeclaration) typeSolver.solveType("com.github.javaparser.ast.Modifier");
+        assertEquals("com.github.javaparser.ast", modifier.getPackageName());
+    }
+
+    @Test
+    public void testGetClassName() {
+        JavaParserEnumDeclaration modifier = (JavaParserEnumDeclaration) typeSolver.solveType("com.github.javaparser.ast.Modifier");
+        assertEquals("Modifier", modifier.getClassName());
+    }
+
+    @Test
     public void testGetQualifiedName() {
         JavaParserEnumDeclaration modifier = (JavaParserEnumDeclaration) typeSolver.solveType("com.github.javaparser.ast.Modifier");
         assertEquals("com.github.javaparser.ast.Modifier", modifier.getQualifiedName());

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
@@ -101,6 +101,18 @@ public class JavaParserInterfaceDeclarationTest extends AbstractTest {
     }
 
     @Test
+    public void testGetPackageName() {
+        JavaParserInterfaceDeclaration nodeWithAnnotations = (JavaParserInterfaceDeclaration) typeSolver.solveType("com.github.javaparser.ast.nodeTypes.NodeWithAnnotations");
+        assertEquals("com.github.javaparser.ast.nodeTypes", nodeWithAnnotations.getPackageName());
+    }
+
+    @Test
+    public void testGetClassName() {
+        JavaParserInterfaceDeclaration nodeWithAnnotations = (JavaParserInterfaceDeclaration) typeSolver.solveType("com.github.javaparser.ast.nodeTypes.NodeWithAnnotations");
+        assertEquals("NodeWithAnnotations", nodeWithAnnotations.getClassName());
+    }
+
+    @Test
     public void testGetQualifiedName() {
         JavaParserInterfaceDeclaration nodeWithAnnotations = (JavaParserInterfaceDeclaration) typeSolver.solveType("com.github.javaparser.ast.nodeTypes.NodeWithAnnotations");
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithAnnotations", nodeWithAnnotations.getQualifiedName());

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
@@ -105,6 +105,18 @@ public class JavassistClassDeclarationTest extends AbstractTest {
     }
 
     @Test
+    public void testGetPackageName() {
+        JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+        assertEquals("com.github.javaparser.ast", compilationUnit.getPackageName());
+    }
+
+    @Test
+    public void testGetClassName() {
+        JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+        assertEquals("CompilationUnit", compilationUnit.getClassName());
+    }
+
+    @Test
     public void testGetQualifiedName() {
         JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
         assertEquals("com.github.javaparser.ast.CompilationUnit", compilationUnit.getQualifiedName());

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclarationTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclarationTest.java
@@ -98,6 +98,18 @@ public class JavassistEnumDeclarationTest extends AbstractTest {
     }
 
     @Test
+    public void testGetPackageName() {
+        EnumDeclaration modifier = (EnumDeclaration) typeSolver.solveType("com.github.javaparser.ast.Modifier");
+        assertEquals("com.github.javaparser.ast", modifier.getPackageName());
+    }
+
+    @Test
+    public void testGetClassName() {
+        EnumDeclaration modifier = (EnumDeclaration) typeSolver.solveType("com.github.javaparser.ast.Modifier");
+        assertEquals("Modifier", modifier.getClassName());
+    }
+
+    @Test
     public void testGetQualifiedName() {
         EnumDeclaration modifier = (EnumDeclaration) typeSolver.solveType("com.github.javaparser.ast.Modifier");
         assertEquals("com.github.javaparser.ast.Modifier", modifier.getQualifiedName());

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclarationTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclarationTest.java
@@ -97,6 +97,18 @@ public class JavassistInterfaceDeclarationTest extends AbstractTest {
     }
 
     @Test
+    public void testGetPackageName() {
+        JavassistInterfaceDeclaration nodeWithAnnotations = (JavassistInterfaceDeclaration) typeSolver.solveType("com.github.javaparser.ast.nodeTypes.NodeWithAnnotations");
+        assertEquals("com.github.javaparser.ast.nodeTypes", nodeWithAnnotations.getPackageName());
+    }
+
+    @Test
+    public void testGetClassName() {
+        JavassistInterfaceDeclaration nodeWithAnnotations = (JavassistInterfaceDeclaration) typeSolver.solveType("com.github.javaparser.ast.nodeTypes.NodeWithAnnotations");
+        assertEquals("NodeWithAnnotations", nodeWithAnnotations.getClassName());
+    }
+
+    @Test
     public void testGetQualifiedName() {
         JavassistInterfaceDeclaration nodeWithAnnotations = (JavassistInterfaceDeclaration) typeSolver.solveType("com.github.javaparser.ast.nodeTypes.NodeWithAnnotations");
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithAnnotations", nodeWithAnnotations.getQualifiedName());

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
@@ -222,6 +222,24 @@ public class ReflectionClassDeclarationTest {
     }
 
     @Test
+    public void testGetPackageName() {
+        TypeSolver typeResolver = new ReflectionTypeSolver();
+        ClassDeclaration arraylist = new ReflectionClassDeclaration(ArrayList.class, typeResolver);
+        assertEquals("java.util", arraylist.getPackageName());
+        ClassDeclaration string = new ReflectionClassDeclaration(String.class, typeResolver);
+        assertEquals("java.lang", string.getPackageName());
+    }
+
+    @Test
+    public void testGetClassName() {
+        TypeSolver typeResolver = new ReflectionTypeSolver();
+        ClassDeclaration arraylist = new ReflectionClassDeclaration(ArrayList.class, typeResolver);
+        assertEquals("ArrayList", arraylist.getClassName());
+        ClassDeclaration string = new ReflectionClassDeclaration(String.class, typeResolver);
+        assertEquals("String", string.getClassName());
+    }
+
+    @Test
     public void testGetQualifiedName() {
         TypeSolver typeResolver = new ReflectionTypeSolver();
         ClassDeclaration arraylist = new ReflectionClassDeclaration(ArrayList.class, typeResolver);

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclarationTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclarationTest.java
@@ -86,6 +86,18 @@ public class ReflectionEnumDeclarationTest extends AbstractTest {
     }
 
     @Test
+    public void testGetPackageName() {
+        ReflectionEnumDeclaration modifier = (ReflectionEnumDeclaration) typeSolver.solveType("com.github.javaparser.ast.Modifier");
+        assertEquals("com.github.javaparser.ast", modifier.getPackageName());
+    }
+
+    @Test
+    public void testGetClassName() {
+        ReflectionEnumDeclaration modifier = (ReflectionEnumDeclaration) typeSolver.solveType("com.github.javaparser.ast.Modifier");
+        assertEquals("Modifier", modifier.getClassName());
+    }
+
+    @Test
     public void testGetQualifiedName() {
         ReflectionEnumDeclaration modifier = (ReflectionEnumDeclaration) typeSolver.solveType("com.github.javaparser.ast.Modifier");
         assertEquals("com.github.javaparser.ast.Modifier", modifier.getQualifiedName());

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
@@ -103,6 +103,16 @@ public class DefaultPackageTest {
         }
 
         @Override
+        public String getPackageName() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getClassName() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public String getQualifiedName() {
             return qualifiedName;
         }

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/MethodLikeDeclaration.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/MethodLikeDeclaration.java
@@ -24,6 +24,19 @@ import java.util.Optional;
  * @author Federico Tomassetti
  */
 public interface MethodLikeDeclaration extends Declaration, TypeParametrizable, HasAccessLevel {
+    /**
+     * The package name of the declaring type.
+     */
+    default String getPackageName() {
+        return declaringType().getPackageName();
+    }
+
+    /**
+     * The class(es) wrapping the declaring type.
+     */
+    default String getClassName() {
+        return declaringType().getClassName();
+    }
 
     /**
      * The qualified name of the method composed by the qualfied name of the declaring type

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/TypeDeclaration.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/TypeDeclaration.java
@@ -123,6 +123,16 @@ public interface TypeDeclaration extends Declaration {
     }
 
     /**
+     * The package name of the type.
+     */
+    String getPackageName();
+
+    /**
+     * The class(es) wrapping this type.
+     */
+    String getClassName();
+
+    /**
      * The fully qualified name of the type declared.
      */
     String getQualifiedName();

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/TypeParameterDeclaration.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/TypeParameterDeclaration.java
@@ -92,6 +92,22 @@ public interface TypeParameterDeclaration extends TypeDeclaration {
     boolean declaredOnMethod();
 
     /**
+     * The package name of the type bound(s).
+     * This is unsupported because there is no package for a Type Parameter, only for its container.
+     */
+    default String getPackageName() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * The class(es) wrapping the type bound(s).
+     * This is unsupported because there is no class for a Type Parameter, only for its container.
+     */
+    default String getClassName() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * The qualified name of the Type Parameter.
      * It is composed by the qualified name of the container followed by a dot and the name of the Type Parameter.
      * The qualified name of a method is its qualified signature.


### PR DESCRIPTION
Fixes #190

The methods in `Helper` are mostly the same, just split between two methods now. The biggest difference is that I added support for `EnumDeclaration`.

I left `getPackageName()`/`getClassName()` as unsupported for `TypeParameterDeclaration` as the qualified name refers to its container, not the type of the parameter itself.

I'd also like to point out that in the Javassist classes, I added `.replace('$', '.')` to `getQualifiedName()` as it appeared to be missing for Interfaces and Enums. Let me know if there is a reason that it was missing and I can revert that change.