### PR TITLE
Allow inferring types for block lambdas

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodResolutionLogic.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodResolutionLogic.java
@@ -127,13 +127,19 @@ class ReflectionMethodResolutionLogic {
     private static MethodUsage replaceParams(List<Type> typeParameterValues, ReferenceTypeDeclaration typeParametrizable, MethodDeclaration methodDeclaration) {
         MethodUsage methodUsage = new MethodUsage(methodDeclaration);
         int i = 0;
-        for (TypeParameterDeclaration tp : typeParametrizable.getTypeParameters()) {
-            methodUsage = methodUsage.replaceTypeParameter(tp, typeParameterValues.get(i));
-            i++;
+
+        // Only replace if we have enough values provided
+        if (typeParameterValues.size() == typeParametrizable.getTypeParameters().size()){
+            for (TypeParameterDeclaration tp : typeParametrizable.getTypeParameters()) {
+                methodUsage = methodUsage.replaceTypeParameter(tp, typeParameterValues.get(i));
+                i++;
+            }
         }
+
         for (TypeParameterDeclaration methodTypeParameter : methodDeclaration.getTypeParameters()) {
             methodUsage = methodUsage.replaceTypeParameter(methodTypeParameter, new TypeVariable(methodTypeParameter));
         }
+
         return methodUsage;
     }
 }

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
@@ -132,6 +132,46 @@ public class LambdaResolutionTest extends AbstractResolutionTest {
         assertEquals("java.util.List<java.lang.String>", type.describe());
     }
 
+    @Test
+    public void lambdaBlockImpliedReturn() throws ParseException {
+        CompilationUnit cu = parseSample("LambdaMulti");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Agenda");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "lambdaImpliedReturn");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        Expression expression = returnStmt.getExpression().get();
+
+        JavaParserFacade javaParserFacade = JavaParserFacade.get(new ReflectionTypeSolver());
+        Type type = javaParserFacade.getType(expression);
+        assertEquals("java.lang.String", type.describe());
+    }
+
+
+    @Test
+    public void lambdaBlockExplicitReturn() throws ParseException {
+        CompilationUnit cu = parseSample("LambdaMulti");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Agenda");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "lambdaSingleReturn");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        Expression expression = returnStmt.getExpression().get();
+
+        JavaParserFacade javaParserFacade = JavaParserFacade.get(new ReflectionTypeSolver());
+        Type type = javaParserFacade.getType(expression);
+        assertEquals("java.lang.String", type.describe());
+    }
+
+    @Test
+    public void lambdaBlockMultiLineReturn() throws ParseException {
+        CompilationUnit cu = parseSample("LambdaMulti");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Agenda");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "multiLineReturn");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        Expression expression = returnStmt.getExpression().get();
+
+        JavaParserFacade javaParserFacade = JavaParserFacade.get(new ReflectionTypeSolver());
+        Type type = javaParserFacade.getType(expression);
+        assertEquals("java.lang.String", type.describe());
+    }
+
 
 
 

--- a/java-symbol-solver-core/src/test/resources/LambdaMulti.java.txt
+++ b/java-symbol-solver-core/src/test/resources/LambdaMulti.java.txt
@@ -1,0 +1,32 @@
+import java.util.List;
+import java.util.stream.IntStream;
+
+public class Agenda {
+
+    private List<String> persons;
+
+    public void lambdaImpliedReturn() {
+        return persons.stream().parallel().map(i -> {
+            addPerson("");
+        }).findFirst().get();
+    }
+
+    public void lambdaSingleReturn() {
+        return persons.stream().parallel().map(i -> {
+            return addPerson("");
+        }).findFirst().get();
+    }
+
+    public void multiLineReturn() {
+        return persons.stream().parallel().map(i -> {
+            int irrelevant;
+            return addPerson("");
+        }).findFirst().get();
+    }
+
+
+    String addPerson(String x){
+
+    }
+
+}


### PR DESCRIPTION
Add support for lambdas with blocks eg.

```
i -> {
    return 2;
}
```

```
i -> {
    foo();
}
```

```
i -> {
    int x;
    return foo(x);
}
```