### PR TITLE
updated Guava version from 18.0 to 21.0

### DIFF
--- a/java-symbol-solver-core/build.gradle
+++ b/java-symbol-solver-core/build.gradle
@@ -2,7 +2,7 @@ description = ''
 dependencies {
     compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.2.0'
     compile group: 'org.javassist', name: 'javassist', version: '3.19.0-GA'
-    compile group: 'com.google.guava', name: 'guava', version: '18.0'
+    compile group: 'com.google.guava', name: 'guava', version: '21.0'
     compile project(':java-symbol-solver-model')
     compile project(':java-symbol-solver-logic')
     compile group: 'io.javaslang', name: 'javaslang', version: '2.0.3'

--- a/java-symbol-solver-examples/build.gradle
+++ b/java-symbol-solver-examples/build.gradle
@@ -1,7 +1,7 @@
 
 description = ''
 dependencies {
-    compile group: 'com.google.guava', name: 'guava', version:'18.0'
+    compile group: 'com.google.guava', name: 'guava', version:'21.0'
     compile project(':java-symbol-solver-core')
     testCompile group: 'junit', name: 'junit', version:'4.12'
     testCompile group: 'org.easymock', name: 'easymock', version:'3.3.1'

--- a/java-symbol-solver-logic/build.gradle
+++ b/java-symbol-solver-logic/build.gradle
@@ -2,7 +2,7 @@ description = ''
 dependencies {
     compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.2.0'
     compile group: 'org.javassist', name: 'javassist', version: '3.19.0-GA'
-    compile group: 'com.google.guava', name: 'guava', version: '18.0'
+    compile group: 'com.google.guava', name: 'guava', version: '21.0'
     compile project(':java-symbol-solver-model')
     compile group: 'com.javaslang', name: 'javaslang', version: '2.0.0-beta'
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/java-symbol-solver-model/build.gradle
+++ b/java-symbol-solver-model/build.gradle
@@ -18,7 +18,7 @@ description = ''
 dependencies {
     compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.2.0'
     compile group: 'org.javassist', name: 'javassist', version: '3.19.0-GA'
-    compile group: 'com.google.guava', name: 'guava', version: '18.0'
+    compile group: 'com.google.guava', name: 'guava', version: '21.0'
     compile group: 'com.javaslang', name: 'javaslang', version: '2.0.0-beta'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.easymock', name: 'easymock', version: '3.3.1'


### PR DESCRIPTION
Just updated Guava version 18.0 to 21.0. All tests pass on my MacBook Pro running OSX 10.11.6.