### PR TITLE
Make the MethodUsage type param map correct in more cases

### DIFF
--- a/java-symbol-solver-core/src/test/resources/MethodCalls.java.txt
+++ b/java-symbol-solver-core/src/test/resources/MethodCalls.java.txt
@@ -48,4 +48,17 @@ class MethodCalls {
         this.variadicMethod("test");
     }
 
+    <T> T genericMethod0() { return null; }
+    <T> T genericMethod1(T x) { return x; }
+
+    static <T> T staticGenericMethod0() { return null; }
+    static <T> T staticGenericMethod1(T x) { return x; }
+
+    void genericMethodTest() {
+        this.<Integer>genericMethod0();
+        this.genericMethod1("Hello");
+
+        MethodCalls.<Integer>staticGenericMethod0();
+        MethodCalls.staticGenericMethod1("Hello");
+    }
 }

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/methods/MethodUsage.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/methods/MethodUsage.java
@@ -47,10 +47,14 @@ public class MethodUsage implements TypeParametrized {
     }
 
     public MethodUsage(MethodDeclaration declaration, List<Type> paramTypes, Type returnType) {
-        this.typeParametersMap = TypeParametersMap.empty();
+        this(declaration, paramTypes, returnType, TypeParametersMap.empty());
+    }
+
+    private MethodUsage(MethodDeclaration declaration, List<Type> paramTypes, Type returnType, TypeParametersMap typeParametersMap) {
         this.declaration = declaration;
         this.paramTypes = paramTypes;
         this.returnType = returnType;
+        this.typeParametersMap = typeParametersMap;
     }
 
     @Override
@@ -87,14 +91,14 @@ public class MethodUsage implements TypeParametrized {
         }
         List<Type> newParams = new LinkedList<>(paramTypes);
         newParams.set(i, replaced);
-        return new MethodUsage(declaration, newParams, returnType);
+        return new MethodUsage(declaration, newParams, returnType, typeParametersMap);
     }
 
     public MethodUsage replaceReturnType(Type returnType) {
         if (returnType == this.returnType) {
             return this;
         } else {
-            return new MethodUsage(declaration, paramTypes, returnType);
+            return new MethodUsage(declaration, paramTypes, returnType, typeParametersMap);
         }
     }
 
@@ -116,8 +120,10 @@ public class MethodUsage implements TypeParametrized {
         if (type == null) {
             throw new IllegalArgumentException();
         }
+
         // TODO if the method declaration has a type param with that name ignore this call
-        MethodUsage res = this;
+        MethodUsage res = new MethodUsage(declaration, paramTypes, returnType, typeParametersMap.toBuilder().setValue(typeParameter, type).build());
+
         Map<TypeParameterDeclaration, Type> inferredTypes = new HashMap<>();
         for (int i = 0; i < paramTypes.size(); i++) {
             Type originalParamType = paramTypes.get(i);

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/parametrization/TypeParametersMap.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/parametrization/TypeParametersMap.java
@@ -50,6 +50,7 @@ public class TypeParametersMap {
         }
 
         public Builder setValue(TypeParameterDeclaration typeParameter, Type value) {
+            // TODO: we shouldn't just silently overwrite existing types!
             String qualifiedName = typeParameter.getQualifiedName();
             nameToValue.put(qualifiedName, value);
             nameToDeclaration.put(qualifiedName, typeParameter);


### PR DESCRIPTION
The status quo is that the typeParametersMap in MethodUsage is usually empty. This commit fixes things up so that it at least has a chance of being right in the result of solveMethodAsUsage (for the case where a method call has type args).

I think that there is probably still a lot of work to be done to make the method resolution logic 100% correct, but this is probably a step in the right direction.