### PR TITLE
Allow best effort symbol solving of a class

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -161,7 +161,11 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
         List<ReferenceType> interfaces = new ArrayList<>();
         if (wrappedNode.getImplementedTypes() != null) {
             for (ClassOrInterfaceType t : wrappedNode.getImplementedTypes()) {
-                interfaces.add(toReferenceType(t));
+                try {
+                    interfaces.add(toReferenceType(t));
+                } catch (UnsolvedSymbolException e) {
+                    // Just ignore
+                }
             }
         }
         return interfaces;
@@ -285,8 +289,12 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
         }
         if (wrappedNode.getImplementedTypes() != null) {
             for (ClassOrInterfaceType implemented : wrappedNode.getImplementedTypes()) {
-                ReferenceType ancestor = toReferenceType(implemented);
-                ancestors.add(ancestor);
+                try {
+                    ReferenceType ancestor = toReferenceType(implemented);
+                    ancestors.add(ancestor);
+                } catch (UnsolvedSymbolException e) {
+                    // Ignore
+                }
             }
         }
         return ancestors;


### PR DESCRIPTION
I'm trying to symbol solve a single class file for uses of the guava library.

Thus, I have a file something like the below.  It should be possible to solve to the call to Files.newWriterSupplier, but currently jss errors out because it can't solve for AggregatedEventListener.  Adding the try catches above fixes the problem, but it probably introduces some hard to trace errors (ie if the private variable had been defined in AggregatedEventListener) which would cause solving to fail.  Any thoughts on implementing an option to ignore those failures and do best effort solving?  (I'm sure this isn't the pull request to do that, but it seemed like the best way to communicate my proposed changes.)  I am, however, happy to help make a better pull request if you are interested in the idea and can point me to a proposed method of implementing as I don't like running code forked off a packaged library if I can avoid it. :)

PS For the sake of example assume, AggregatedEventListener is missing.  In actuality, the problem is that I'm parsing a project with multiple java roots which haven't been bound in so JSS can't find the class.  If you know of an automated way to find all the java project roots in a maven project, that would decrease the need for this, but even still, I could see how there might be some other dependency that is unavailable but they extend/implement a part of it where "best effort" solving would be useful.

This is also somewhat related to #135. 

```
import com.google.common.io.Closeables;
import com.google.common.io.Files;
import com.google.common.base.Charsets;

public class TextReport implements AggregatedEventListener {
      private File outputFile;
  @Override
  public void setOuter(JUnit4 task) {
    if (outputFile != null) {
      try {
        Files.createParentDirs(outputFile);
        this.output = Files.newWriterSupplier(outputFile, Charsets.UTF_8, append).getOutput();
      } catch (IOException e) {
        throw new BuildException(e);
      }
    }
  }
}
```