### PR TITLE
Fix Infinite Recursion

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -92,14 +92,17 @@ public class JavaParserTypeDeclarationAdapter {
         // We want to avoid infinite recursion in case of Object having Object as ancestor
         if (!Object.class.getCanonicalName().equals(typeDeclaration.getQualifiedName())) {
             for (ReferenceType ancestor : typeDeclaration.getAncestors()) {
-                SymbolReference<MethodDeclaration> res = MethodResolutionLogic
-                        .solveMethodInType(ancestor.getTypeDeclaration(), name, argumentsTypes, staticOnly, typeSolver);
-                // consider methods from superclasses and only default methods from interfaces :
-                // not true, we should keep abstract as a valid candidate
-                // abstract are removed in MethodResolutionLogic.isApplicable is necessary
-                if (res.isSolved()) {
-                    candidateMethods.add(res.getCorrespondingDeclaration());
-                }
+		// Avoid recursion on self
+                if (typeDeclaration != ancestor.getTypeDeclaration()) {
+                    SymbolReference<MethodDeclaration> res = MethodResolutionLogic
+                            .solveMethodInType(ancestor.getTypeDeclaration(), name, argumentsTypes, staticOnly, typeSolver);
+                    // consider methods from superclasses and only default methods from interfaces :
+                    // not true, we should keep abstract as a valid candidate
+                    // abstract are removed in MethodResolutionLogic.isApplicable is necessary
+                    if (res.isSolved()) {
+                        candidateMethods.add(res.getCorrespondingDeclaration());
+                    }
+		}
             }
         }
         // We want to avoid infinite recursion when a class is using its own method

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -197,7 +197,11 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration impl
             }
         }
 
-        getAncestors().forEach(a -> fields.addAll(a.getTypeDeclaration().getAllFields()));
+        getAncestors().forEach(a -> {
+            if (a.getTypeDeclaration() != this) {
+                fields.addAll(a.getTypeDeclaration().getAllFields());
+            }
+        });
 
         return fields;
     }


### PR DESCRIPTION
I think I've found and fixed two more places where infinite recursion can occur in java symbol solver.  At the very least, I tracked down infinite recursions in my runs to these lines and these changes fixed them for me.  It makes since that you shouldn't recurse onto yourself.  The better question might be why self is an ancestor by getAncestors, but I couldn't find a clear way to detect/fix that since the classes weren't the same, which is why I went down this route.