### PR TITLE
Fixed #218, where ./gradlew install set the version to "unspecified"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ allprojects  {
   apply plugin: 'jacoco'
 
   group = 'com.github.javaparser'
+  version = jssVersion
 
   repositories {
     mavenCentral()


### PR DESCRIPTION
See also http://stackoverflow.com/questions/34377367/why-is-gradle-install-replacing-my-version-with-unspecified.