### PR TITLE
Implementation of getAncestors() in JavassistEnumDeclaration

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistConstructorDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistConstructorDeclaration.java
@@ -118,6 +118,6 @@ public class JavassistConstructorDeclaration implements ConstructorDeclaration {
 
     @Override
     public AccessLevel accessLevel() {
-        throw new UnsupportedOperationException();
+        return JavassistFactory.modifiersToAccessLevel(ctConstructor.getModifiers());
     }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -84,7 +84,32 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration implements
 
     @Override
     public List<ReferenceType> getAncestors() {
-        throw new UnsupportedOperationException();
+        // Direct ancestors of an enum are java.lang.Enum and interfaces
+        List<ReferenceType> ancestors = new LinkedList<>();
+
+        try {
+            CtClass superClass = ctClass.getSuperclass();
+
+            if (superClass != null) {
+                Type superClassTypeUsage = JavassistFactory.typeUsageFor(superClass, typeSolver);
+
+                if (superClassTypeUsage.isReferenceType()) {
+                    ancestors.add(superClassTypeUsage.asReferenceType());
+                }
+            }
+
+            for (CtClass interfaze : ctClass.getInterfaces()) {
+                Type interfazeTypeUsage = JavassistFactory.typeUsageFor(interfaze, typeSolver);
+
+                if (interfazeTypeUsage.isReferenceType()) {
+                    ancestors.add(interfazeTypeUsage.asReferenceType());
+                }
+            }
+        } catch (NotFoundException e) {
+            throw new RuntimeException("Ancestor not found for " + ctClass.getName() + ".", e);
+        }
+
+        return ancestors;
     }
 
     @Override


### PR DESCRIPTION
This PR implements the missing `getAncestors()` in `JavassistEnumDeclaration` and `accessLevel()` in `JavassistConstructorDeclaration`. `getAncestors()` only returns direct ancestors as written in the corresponding interface.
java.lang.Enum is also added in the list as the only ancestor class of the enum.