### PR TITLE
fix issue #235

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
@@ -68,6 +68,9 @@ public class JavaParserFactory {
             return new StatementContext<Statement>((Statement) node, typeSolver);
         } else if (node instanceof CatchClause) {
             return new CatchClauseContext((CatchClause) node, typeSolver);
+        } else if (node instanceof ObjectCreationExpr &&
+            ((ObjectCreationExpr) node).getAnonymousClassBody().isPresent()) {
+            return new AnonymousClassDeclarationContext((ObjectCreationExpr) node, typeSolver);
         } else {
             if (node instanceof NameExpr) {
                 // to resolve a name when in a fieldAccess context, we can get to the grand parent to prevent a infinite loop if the name is the same as the field (ie x.x)
@@ -78,9 +81,6 @@ public class JavaParserFactory {
             final Node parentNode = getParentNode(node);
             if(parentNode instanceof ObjectCreationExpr && node == ((ObjectCreationExpr) parentNode).getType()) {
                 return getContext(getParentNode(parentNode), typeSolver);
-            } else if (node instanceof ObjectCreationExpr &&
-                ((ObjectCreationExpr) node).getAnonymousClassBody().isPresent()) {
-                return new AnonymousClassDeclarationContext((ObjectCreationExpr) node, typeSolver);
             }
             return getContext(parentNode, typeSolver);
         }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
@@ -68,9 +68,6 @@ public class JavaParserFactory {
             return new StatementContext<Statement>((Statement) node, typeSolver);
         } else if (node instanceof CatchClause) {
             return new CatchClauseContext((CatchClause) node, typeSolver);
-        } else if (node instanceof ObjectCreationExpr &&
-            ((ObjectCreationExpr) node).getAnonymousClassBody().isPresent()) {
-            return new AnonymousClassDeclarationContext((ObjectCreationExpr) node, typeSolver);
         } else {
             if (node instanceof NameExpr) {
                 // to resolve a name when in a fieldAccess context, we can get to the grand parent to prevent a infinite loop if the name is the same as the field (ie x.x)
@@ -78,7 +75,14 @@ public class JavaParserFactory {
                     return getContext(node.getParentNode().get().getParentNode().get(), typeSolver);
                 }
             }
-            return getContext(getParentNode(node), typeSolver);
+            final Node parentNode = getParentNode(node);
+            if(parentNode instanceof ObjectCreationExpr && node == ((ObjectCreationExpr) parentNode).getType()) {
+                return getContext(getParentNode(parentNode), typeSolver);
+            } else if (node instanceof ObjectCreationExpr &&
+                ((ObjectCreationExpr) node).getAnonymousClassBody().isPresent()) {
+                return new AnonymousClassDeclarationContext((ObjectCreationExpr) node, typeSolver);
+            }
+            return getContext(parentNode, typeSolver);
         }
     }
 

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/Issue235.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/Issue235.java
@@ -18,7 +18,6 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 @RunWith(Parameterized.class)
 public class Issue235 extends AbstractResolutionTest{
@@ -31,7 +30,8 @@ public class Issue235 extends AbstractResolutionTest{
     @Parameterized.Parameters(name = "{0}")
     public static Collection<String> data() throws Exception {
         return Arrays.asList(
-                "new_bar_Baz",
+                "new_Bar_Baz_direct",
+                "new_Bar_Baz",
                 "new_Bar",
                 "new_Foo_Bar"
         );
@@ -43,13 +43,9 @@ public class Issue235 extends AbstractResolutionTest{
         ClassOrInterfaceDeclaration cls = Navigator.demandClassOrInterface(cu, "Foo");
         TypeSolver typeSolver = new ReflectionTypeSolver();
         JavaParserFacade javaParserFacade = JavaParserFacade.get(typeSolver);
-        ExpressionStmt stmt;
-        ObjectCreationExpr expression;
-        MethodDeclaration m;
-
-        m = Navigator.demandMethod(cls, this.method);
-        stmt = (ExpressionStmt) m.getBody().get().getStatements().get(0);
-        expression = (ObjectCreationExpr) stmt.getExpression();
+        MethodDeclaration m = Navigator.demandMethod(cls, this.method);
+        ExpressionStmt stmt = (ExpressionStmt) m.getBody().get().getStatements().get(0);
+        ObjectCreationExpr expression = (ObjectCreationExpr) stmt.getExpression();
         Assert.assertNotNull(javaParserFacade.convertToUsage(expression.getType()));
     }
 }

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/Issue235.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/Issue235.java
@@ -13,8 +13,30 @@ import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+@RunWith(Parameterized.class)
 public class Issue235 extends AbstractResolutionTest{
+    private final String method;
+
+    public Issue235(String method) {
+        this.method = method;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<String> data() throws Exception {
+        return Arrays.asList(
+                "new_bar_Baz",
+                "new_Bar",
+                "new_Foo_Bar"
+        );
+    }
+
     @Test
     public void issue235() throws ParseException {
         CompilationUnit cu = parseSample("Issue235");
@@ -25,17 +47,7 @@ public class Issue235 extends AbstractResolutionTest{
         ObjectCreationExpr expression;
         MethodDeclaration m;
 
-        m = Navigator.demandMethod(cls, "correct1");
-        stmt = (ExpressionStmt) m.getBody().get().getStatements().get(0);
-        expression = (ObjectCreationExpr) stmt.getExpression();
-        Assert.assertNotNull(javaParserFacade.convertToUsage(expression.getType()));
-
-        m = Navigator.demandMethod(cls, "correct2");
-        stmt = (ExpressionStmt) m.getBody().get().getStatements().get(0);
-        expression = (ObjectCreationExpr) stmt.getExpression();
-        Assert.assertNotNull(javaParserFacade.convertToUsage(expression.getType()));
-
-        m = Navigator.demandMethod(cls, "failing");
+        m = Navigator.demandMethod(cls, this.method);
         stmt = (ExpressionStmt) m.getBody().get().getStatements().get(0);
         expression = (ObjectCreationExpr) stmt.getExpression();
         Assert.assertNotNull(javaParserFacade.convertToUsage(expression.getType()));

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/Issue235.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/Issue235.java
@@ -1,0 +1,43 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.ParseException;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Issue235 extends AbstractResolutionTest{
+    @Test
+    public void issue235() throws ParseException {
+        CompilationUnit cu = parseSample("Issue235");
+        ClassOrInterfaceDeclaration cls = Navigator.demandClassOrInterface(cu, "Foo");
+        TypeSolver typeSolver = new ReflectionTypeSolver();
+        JavaParserFacade javaParserFacade = JavaParserFacade.get(typeSolver);
+        ExpressionStmt stmt;
+        ObjectCreationExpr expression;
+        MethodDeclaration m;
+
+        m = Navigator.demandMethod(cls, "correct1");
+        stmt = (ExpressionStmt) m.getBody().get().getStatements().get(0);
+        expression = (ObjectCreationExpr) stmt.getExpression();
+        Assert.assertNotNull(javaParserFacade.convertToUsage(expression.getType()));
+
+        m = Navigator.demandMethod(cls, "correct2");
+        stmt = (ExpressionStmt) m.getBody().get().getStatements().get(0);
+        expression = (ObjectCreationExpr) stmt.getExpression();
+        Assert.assertNotNull(javaParserFacade.convertToUsage(expression.getType()));
+
+        m = Navigator.demandMethod(cls, "failing");
+        stmt = (ExpressionStmt) m.getBody().get().getStatements().get(0);
+        expression = (ObjectCreationExpr) stmt.getExpression();
+        Assert.assertNotNull(javaParserFacade.convertToUsage(expression.getType()));
+    }
+}

--- a/java-symbol-solver-core/src/test/resources/Issue235.java.txt
+++ b/java-symbol-solver-core/src/test/resources/Issue235.java.txt
@@ -2,13 +2,13 @@ class Foo {
     static class Bar {
         static class Baz {}
     }
-    static void failing() {
+    static void new_bar_Baz() {
         new Bar.Baz() {};
     }
-    static void correct1() {
+    static void new_Bar() {
         new Bar() {};
     }
-    static void correct2() {
+    static void new_Foo_Bar() {
         new Foo.Bar() {};
     }
 }

--- a/java-symbol-solver-core/src/test/resources/Issue235.java.txt
+++ b/java-symbol-solver-core/src/test/resources/Issue235.java.txt
@@ -2,7 +2,10 @@ class Foo {
     static class Bar {
         static class Baz {}
     }
-    static void new_bar_Baz() {
+    static void new_Bar_Baz_direct() {
+        new Bar.Baz();
+    }
+    static void new_Bar_Baz() {
         new Bar.Baz() {};
     }
     static void new_Bar() {

--- a/java-symbol-solver-core/src/test/resources/Issue235.java.txt
+++ b/java-symbol-solver-core/src/test/resources/Issue235.java.txt
@@ -1,0 +1,14 @@
+class Foo {
+    static class Bar {
+        static class Baz {}
+    }
+    static void failing() {
+        new Bar.Baz() {};
+    }
+    static void correct1() {
+        new Bar() {};
+    }
+    static void correct2() {
+        new Foo.Bar() {};
+    }
+}


### PR DESCRIPTION
The problem was that JavaParserFactory.getContext() didn't checked if a ObjectCreationExpr was visited from its type branch or from its class body branch.

I guess the type branch is outside of the scope of the class and belongs to the parent scope. I can't find this in the JLS, but my tests with the compiler prove my assumption:
```java
interface Test { }
...
new Test<X>() { // <- X is undefined
  class X { }
};
```