### PR TITLE
Use a WeakHashMap to avoid memory leaks in JavaParserFacade.instances

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -64,7 +64,7 @@ public class JavaParserFacade {
         logger.addHandler(consoleHandler);
     }
 
-    private static Map<TypeSolver, JavaParserFacade> instances = new HashMap<>();
+    private static Map<TypeSolver, JavaParserFacade> instances = new WeakHashMap<>();
     private TypeSolver typeSolver;
     private SymbolSolver symbolSolver;
     private Map<Node, Type> cacheWithLambdasSolved = new IdentityHashMap<>();
@@ -86,10 +86,7 @@ public class JavaParserFacade {
     }
 
     public static JavaParserFacade get(TypeSolver typeSolver) {
-        if (!instances.containsKey(typeSolver)) {
-            instances.put(typeSolver, new JavaParserFacade(typeSolver));
-        }
-        return instances.get(typeSolver);
+        return instances.computeIfAbsent(typeSolver, JavaParserFacade::new);
     }
 
     /**


### PR DESCRIPTION
It's useful to have weak references of TypeSolver**s**  in the static 'instances'. So, the TypeSolver-->JavaParserFacade entries will be garbage-collected automatically and it's not necessary to call 'clearInstances' explicitly.