### PR TITLE
Implement containerType methods for TypeDeclarations 

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -507,11 +507,7 @@ public class JavaParserFacade {
     }
 
     public ReferenceTypeDeclaration getTypeDeclaration(ClassOrInterfaceDeclaration classOrInterfaceDeclaration) {
-        if (classOrInterfaceDeclaration.isInterface()) {
-            return new JavaParserInterfaceDeclaration(classOrInterfaceDeclaration, typeSolver);
-        } else {
-            return new JavaParserClassDeclaration(classOrInterfaceDeclaration, typeSolver);
-        }
+        return JavaParserFactory.toTypeDeclaration(classOrInterfaceDeclaration, typeSolver);
     }
 
     /**
@@ -530,14 +526,6 @@ public class JavaParserFacade {
     }
 
     public ReferenceTypeDeclaration getTypeDeclaration(com.github.javaparser.ast.body.TypeDeclaration<?> typeDeclaration) {
-        if (typeDeclaration instanceof ClassOrInterfaceDeclaration) {
-            return getTypeDeclaration((ClassOrInterfaceDeclaration) typeDeclaration);
-        } else if (typeDeclaration instanceof EnumDeclaration) {
-            return new JavaParserEnumDeclaration((EnumDeclaration) typeDeclaration, typeSolver);
-        } else if (typeDeclaration instanceof com.github.javaparser.ast.body.AnnotationDeclaration) {
-            return new JavaParserAnnotationDeclaration((com.github.javaparser.ast.body.AnnotationDeclaration) typeDeclaration, typeSolver);
-        } else {
-            throw new UnsupportedOperationException(typeDeclaration.getClass().getCanonicalName());
-        }
+        return JavaParserFactory.toTypeDeclaration(typeDeclaration, typeSolver);
     }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
@@ -21,12 +21,19 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.*;
+import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.symbolsolver.core.resolution.Context;
 import com.github.javaparser.symbolsolver.javaparsermodel.contexts.*;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserAnnotationDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserEnumDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserInterfaceDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserTypeParameter;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarators.FieldSymbolDeclarator;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarators.NoSymbolDeclarator;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarators.ParameterSymbolDeclarator;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarators.VariableSymbolDeclarator;
+import com.github.javaparser.symbolsolver.model.declarations.ReferenceTypeDeclaration;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.resolution.SymbolDeclarator;
 
@@ -107,5 +114,22 @@ public class JavaParserFactory {
             return new NoSymbolDeclarator<Node>(node, typeSolver);
         }
     }
-
+    
+    public static ReferenceTypeDeclaration toTypeDeclaration(Node node, TypeSolver typeSolver) {
+        if (node instanceof ClassOrInterfaceDeclaration) {
+            if (((ClassOrInterfaceDeclaration) node).isInterface()) {
+                return new JavaParserInterfaceDeclaration((ClassOrInterfaceDeclaration) node, typeSolver);
+            } else {
+                return new JavaParserClassDeclaration((ClassOrInterfaceDeclaration) node, typeSolver);
+            }
+        } else if (node instanceof TypeParameter) {
+            return new JavaParserTypeParameter((TypeParameter) node, typeSolver);
+        } else if (node instanceof EnumDeclaration) {
+            return new JavaParserEnumDeclaration((EnumDeclaration) node, typeSolver);
+        } else if (node instanceof AnnotationDeclaration) {
+            return new JavaParserAnnotationDeclaration((AnnotationDeclaration) node, typeSolver);
+        } else {
+            throw new IllegalArgumentException(node.getClass().getCanonicalName());
+        }
+    }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
@@ -7,6 +7,7 @@ import com.github.javaparser.symbolsolver.model.typesystem.ReferenceType;
 import com.github.javaparser.symbolsolver.model.typesystem.Type;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.github.javaparser.symbolsolver.javaparser.Navigator.getParentNode;
@@ -82,5 +83,10 @@ public class JavaParserAnnotationDeclaration extends AbstractTypeDeclaration imp
     @Override
     public List<TypeParameterDeclaration> getTypeParameters() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<ReferenceTypeDeclaration> containerType() {
+        throw new UnsupportedOperationException("containerType is not supported for " + this.getClass().getCanonicalName());
     }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -193,5 +194,10 @@ public class JavaParserAnonymousClassDeclaration extends AbstractClassDeclaratio
   @Override
   public List<TypeParameterDeclaration> getTypeParameters() {
     return Lists.newArrayList();
+  }
+
+  @Override
+  public Optional<ReferenceTypeDeclaration> containerType() {
+    throw new UnsupportedOperationException("containerType is not supported for " + this.getClass().getCanonicalName());
   }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -24,7 +24,6 @@ import com.github.javaparser.symbolsolver.core.resolution.Context;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.javaparsermodel.UnsolvedSymbolException;
-import com.github.javaparser.symbolsolver.javassistmodel.JavassistFactory;
 import com.github.javaparser.symbolsolver.logic.AbstractClassDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.*;
 import com.github.javaparser.symbolsolver.model.declarations.ConstructorDeclaration;
@@ -39,7 +38,6 @@ import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.symbolsolver.model.typesystem.Type;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 import com.google.common.collect.ImmutableList;
-import com.sun.org.apache.xerces.internal.dom.ParentNode;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -24,6 +24,7 @@ import com.github.javaparser.symbolsolver.core.resolution.Context;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.javaparsermodel.UnsolvedSymbolException;
+import com.github.javaparser.symbolsolver.javassistmodel.JavassistFactory;
 import com.github.javaparser.symbolsolver.logic.AbstractClassDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.*;
 import com.github.javaparser.symbolsolver.model.declarations.ConstructorDeclaration;
@@ -38,6 +39,7 @@ import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.symbolsolver.model.typesystem.Type;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 import com.google.common.collect.ImmutableList;
+import com.sun.org.apache.xerces.internal.dom.ParentNode;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -333,6 +335,22 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
         return new ReferenceTypeImpl(typeSolver.solveType(Object.class.getCanonicalName()), typeSolver);
     }
 
+    @Override
+    public Set<ReferenceTypeDeclaration> internalTypes() {
+        Set<ReferenceTypeDeclaration> res = new HashSet<>();
+        for (BodyDeclaration member : this.wrappedNode.getMembers()) {
+            if (member instanceof com.github.javaparser.ast.body.TypeDeclaration) {
+                res.add(JavaParserFacade.get(typeSolver).getTypeDeclaration((com.github.javaparser.ast.body.TypeDeclaration)member));
+            }
+        }
+        return res;
+    }
+
+    @Override
+    public Optional<ReferenceTypeDeclaration> containerType() {
+        return javaParserTypeAdapter.containerType();
+    }
+
     ///
     /// Private methods
     ///
@@ -361,16 +379,5 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
                 .stream().map(ta -> new LazyType(v -> JavaParserFacade.get(typeSolver).convert(ta, ta)))
                 .collect(Collectors.toList());
         return new ReferenceTypeImpl(ref.getCorrespondingDeclaration().asReferenceType(), superClassTypeParameters, typeSolver);
-    }
-
-    @Override
-    public Set<ReferenceTypeDeclaration> internalTypes() {
-        Set<ReferenceTypeDeclaration> res = new HashSet<>();
-        for (BodyDeclaration member : this.wrappedNode.getMembers()) {
-            if (member instanceof com.github.javaparser.ast.body.TypeDeclaration) {
-                res.add(JavaParserFacade.get(typeSolver).getTypeDeclaration((com.github.javaparser.ast.body.TypeDeclaration)member));
-            }
-        }
-        return res;
     }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -332,4 +332,9 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration implement
         }
         return res;
     }
+
+    @Override
+    public Optional<ReferenceTypeDeclaration> containerType() {
+        return javaParserTypeAdapter.containerType();
+    }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserFieldDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserFieldDeclaration.java
@@ -25,7 +25,6 @@ import com.github.javaparser.symbolsolver.model.declarations.AccessLevel;
 import com.github.javaparser.symbolsolver.model.declarations.FieldDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.TypeDeclaration;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
-import com.github.javaparser.symbolsolver.model.typesystem.ArrayType;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.symbolsolver.model.typesystem.Type;
 

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -285,6 +285,11 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration impl
         return res;
     }
 
+    @Override
+    public Optional<ReferenceTypeDeclaration> containerType() {
+        return javaParserTypeAdapter.containerType();
+    }
+
     ///
     /// Private methods
     ///

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
@@ -17,8 +17,6 @@
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.symbolsolver.core.resolution.Context;
 import com.github.javaparser.symbolsolver.declarations.common.MethodDeclarationCommonLogic;

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
@@ -57,20 +57,11 @@ public class JavaParserMethodDeclaration implements MethodDeclaration {
 
     @Override
     public ReferenceTypeDeclaration declaringType() {
-        if (getParentNode(wrappedNode) instanceof ClassOrInterfaceDeclaration) {
-            ClassOrInterfaceDeclaration parent = (ClassOrInterfaceDeclaration) getParentNode(wrappedNode);
-            if (parent.isInterface()) {
-                return new JavaParserInterfaceDeclaration(parent, typeSolver);
-            } else {
-                return new JavaParserClassDeclaration(parent, typeSolver);
-            }
-        } else if (getParentNode(wrappedNode) instanceof EnumDeclaration) {
-            return new JavaParserEnumDeclaration((EnumDeclaration) getParentNode(wrappedNode), typeSolver);
-        } else if (getParentNode(wrappedNode) instanceof ObjectCreationExpr) {
+        if (getParentNode(wrappedNode) instanceof ObjectCreationExpr) {
             ObjectCreationExpr parentNode = (ObjectCreationExpr) getParentNode(wrappedNode);
             return new JavaParserAnonymousClassDeclaration(parentNode, typeSolver);
         } else {
-            throw new UnsupportedOperationException(getParentNode(wrappedNode).getClass().getCanonicalName());
+            return JavaParserFactory.toTypeDeclaration(getParentNode(wrappedNode), typeSolver);
         }
     }
 

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeAdapter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeAdapter.java
@@ -7,6 +7,7 @@ import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.nodeTypes.NodeWithMembers;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithTypeParameters;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.model.declarations.ReferenceTypeDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.TypeDeclaration;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
@@ -14,9 +15,11 @@ import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceType;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.symbolsolver.model.typesystem.Type;
+import com.github.javaparser.symbolsolver.reflectionmodel.ReflectionFactory;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.github.javaparser.symbolsolver.javaparser.Navigator.getParentNode;
 
@@ -107,5 +110,12 @@ public class JavaParserTypeAdapter<T extends Node & NodeWithSimpleName<T> & Node
             }
         }
         return SymbolReference.unsolved(TypeDeclaration.class);
+    }
+
+    public Optional<ReferenceTypeDeclaration> containerType() {
+        Optional<Node> parent = wrappedNode.getParentNode();
+        return parent.isPresent() ? 
+                Optional.of(JavaParserFactory.toTypeDeclaration(parent.get(), typeSolver)) :
+                Optional.empty();
     }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeAdapter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeAdapter.java
@@ -15,7 +15,6 @@ import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceType;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.symbolsolver.model.typesystem.Type;
-import com.github.javaparser.symbolsolver.reflectionmodel.ReflectionFactory;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 
 import java.util.List;

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeParameter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeParameter.java
@@ -212,4 +212,13 @@ public class JavaParserTypeParameter extends AbstractTypeDeclaration implements 
     public String toString() {
         return "JPTypeParameter(" + wrappedNode.getName() + ", bounds=" + wrappedNode.getTypeBound() + ")";
     }
+
+    @Override
+    public Optional<ReferenceTypeDeclaration> containerType() {
+        TypeParametrizable container = getContainer();
+        if (container instanceof ReferenceTypeDeclaration) {
+            return Optional.of((ReferenceTypeDeclaration) container);
+        }
+        return Optional.empty();
+    }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeVariableDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeVariableDeclaration.java
@@ -24,7 +24,6 @@ import com.github.javaparser.symbolsolver.model.declarations.FieldDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.MethodDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.ReferenceTypeDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.TypeParameterDeclaration;
-import com.github.javaparser.symbolsolver.model.declarations.TypeParametrizable;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceType;

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeVariableDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeVariableDeclaration.java
@@ -24,6 +24,7 @@ import com.github.javaparser.symbolsolver.model.declarations.FieldDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.MethodDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.ReferenceTypeDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.TypeParameterDeclaration;
+import com.github.javaparser.symbolsolver.model.declarations.TypeParametrizable;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceType;
@@ -33,6 +34,7 @@ import com.github.javaparser.symbolsolver.model.typesystem.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -177,5 +179,10 @@ public class JavaParserTypeVariableDeclaration extends AbstractTypeDeclaration {
      */
     public TypeParameter getWrappedNode() {
         return wrappedNode;
+    }
+
+    @Override
+    public Optional<ReferenceTypeDeclaration> containerType() {
+        return asTypeParameter().containerType();
     }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeDeclarationAdapter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeDeclarationAdapter.java
@@ -85,7 +85,7 @@ public class JavassistTypeDeclarationAdapter {
     try {
       return ctClass.getDeclaringClass() == null ?
           Optional.empty() :
-          Optional.of(new JavassistClassDeclaration(ctClass.getDeclaringClass(), typeSolver));
+          Optional.of(JavassistFactory.toTypeDeclaration(ctClass.getDeclaringClass(), typeSolver));
     } catch (NotFoundException e) {
       throw new RuntimeException(e);
     }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeParameter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeParameter.java
@@ -26,6 +26,7 @@ import javassist.bytecode.SignatureAttribute;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Federico Tomassetti
@@ -104,5 +105,13 @@ public class JavassistTypeParameter implements TypeParameterDeclaration {
             throw new UnsupportedOperationException(ot.toString());
         }
         return bounds;
+    }
+
+    @Override
+    public Optional<ReferenceTypeDeclaration> containerType() {
+        if (container instanceof ReferenceTypeDeclaration) {
+            return Optional.of((ReferenceTypeDeclaration) container);
+        }
+        return Optional.empty();
     }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassAdapter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassAdapter.java
@@ -180,4 +180,11 @@ class ReflectionClassAdapter {
                 .map(m -> new ReflectionConstructorDeclaration(m, typeSolver))
                 .collect(Collectors.toList());
     }
+    
+    public Optional<ReferenceTypeDeclaration> containerType() {
+        Class<?> declaringClass = clazz.getDeclaringClass();
+        return declaringClass == null ?
+                Optional.empty() :
+                Optional.of(ReflectionFactory.typeDeclarationFor(declaringClass, typeSolver));
+    }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -320,6 +320,11 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration {
     }
 
     @Override
+    public Optional<ReferenceTypeDeclaration> containerType() {
+        return reflectionClassAdapter.containerType();
+    }
+    
+    @Override
     public Set<ReferenceTypeDeclaration> internalTypes() {
         return Arrays.stream(this.clazz.getDeclaredClasses())
                 .map(ic -> ReflectionFactory.typeDeclarationFor(ic, typeSolver))

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
@@ -25,12 +25,8 @@ import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceType;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.symbolsolver.model.typesystem.Type;
-import com.github.javaparser.symbolsolver.resolution.MethodResolutionLogic;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.*;
-import java.util.function.Predicate;
 
 /**
  * @author Federico Tomassetti

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
@@ -78,6 +78,11 @@ public class ReflectionEnumDeclaration extends AbstractTypeDeclaration implement
   public AccessLevel accessLevel() {
     return ReflectionFactory.modifiersToAccessLevel(this.clazz.getModifiers());
   }
+  
+  @Override
+  public Optional<ReferenceTypeDeclaration> containerType() {
+      return reflectionClassAdapter.containerType();
+  }
 
   @Override
   public String getPackageName() {

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -274,6 +274,11 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration impl
         }
         return res;
     }
+    
+    @Override
+    public Optional<ReferenceTypeDeclaration> containerType() {
+        return reflectionClassAdapter.containerType();
+    }
 
     @Override
     public Set<ReferenceTypeDeclaration> internalTypes() {

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -30,13 +30,9 @@ import com.github.javaparser.symbolsolver.model.typesystem.NullType;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceType;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.symbolsolver.model.typesystem.Type;
-import com.github.javaparser.symbolsolver.resolution.MethodResolutionLogic;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.*;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodResolutionLogic.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodResolutionLogic.java
@@ -20,7 +20,6 @@ import com.github.javaparser.symbolsolver.core.resolution.Context;
 import com.github.javaparser.symbolsolver.model.declarations.MethodDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.ReferenceTypeDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.TypeParameterDeclaration;
-import com.github.javaparser.symbolsolver.model.declarations.TypeParametrizable;
 import com.github.javaparser.symbolsolver.model.methods.MethodUsage;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionTypeParameter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionTypeParameter.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.TypeVariable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -118,5 +119,13 @@ public class ReflectionTypeParameter implements TypeParameterDeclaration {
         return "ReflectionTypeParameter{" +
                 "typeVariable=" + typeVariable +
                 '}';
+    }
+
+    @Override
+    public Optional<ReferenceTypeDeclaration> containerType() {
+        if (container instanceof ReferenceTypeDeclaration) {
+            return Optional.of((ReferenceTypeDeclaration) container);
+        }
+        return Optional.empty();
     }
 }

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionTypeParameter.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionTypeParameter.java
@@ -18,7 +18,6 @@ package com.github.javaparser.symbolsolver.reflectionmodel;
 
 import com.github.javaparser.symbolsolver.model.declarations.MethodLikeDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.ReferenceTypeDeclaration;
-import com.github.javaparser.symbolsolver.model.declarations.TypeDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.TypeParameterDeclaration;
 import com.github.javaparser.symbolsolver.model.declarations.TypeParametrizable;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
@@ -1,7 +1,6 @@
 package com.github.javaparser.symbolsolver.resolution;
 
 import com.github.javaparser.JavaParser;
-import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.logic.AbstractClassDeclaration;

--- a/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
+++ b/java-symbol-solver-core/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -115,6 +116,11 @@ public class DefaultPackageTest {
         @Override
         public String getQualifiedName() {
             return qualifiedName;
+        }
+
+        @Override
+        public Optional<ReferenceTypeDeclaration> containerType() {
+            throw new UnsupportedOperationException();
         }
     }
 

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/TypeDeclaration.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/TypeDeclaration.java
@@ -60,13 +60,11 @@ public interface TypeDeclaration extends Declaration {
     }
 
     /**
-     * Get the TypeDeclaration enclosing this declaration.
+     * Get the ReferenceTypeDeclaration enclosing this declaration.
      *
      * @return
      */
-    default Optional<ReferenceTypeDeclaration> containerType() {
-        throw new UnsupportedOperationException("containerType is not supported for " + this.getClass().getCanonicalName());
-    }
+    Optional<ReferenceTypeDeclaration> containerType();
 
     ///
     /// Misc

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/TypeParameterDeclaration.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/TypeParameterDeclaration.java
@@ -20,6 +20,7 @@ import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.typesystem.Type;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Declaration of a type parameter.
@@ -82,6 +83,11 @@ public interface TypeParameterDeclaration extends TypeDeclaration {
             @Override
             public String toString() {
                 return "TypeParameter onType " + name;
+            }
+
+            @Override
+            public Optional<ReferenceTypeDeclaration> containerType() {
+                return Optional.empty();
             }
         };
     }

--- a/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/TypeParameterDeclaration.java
+++ b/java-symbol-solver-model/src/main/java/com/github/javaparser/symbolsolver/model/declarations/TypeParameterDeclaration.java
@@ -87,7 +87,7 @@ public interface TypeParameterDeclaration extends TypeDeclaration {
 
             @Override
             public Optional<ReferenceTypeDeclaration> containerType() {
-                return Optional.empty();
+                throw new UnsupportedOperationException();
             }
         };
     }


### PR DESCRIPTION
* added `toTypeDeclaration` method to JavaParserFactory to remove code duplications.
* implemented containerType method for most of the types that implement TypeDeclaration