### PR TITLE
fixed implemetation of getName method for Javassist type declarations

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -253,7 +253,8 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration {
 
     @Override
     public String getName() {
-        return ctClass.getSimpleName();
+        String[] nameElements = ctClass.getSimpleName().replace('$', '.').split("\\.");
+        return nameElements[nameElements.length - 1];
     }
 
     @Override

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -151,7 +151,8 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration implements
 
     @Override
     public String getName() {
-        return ctClass.getSimpleName();
+        String[] nameElements = ctClass.getSimpleName().replace('$', '.').split("\\.");
+        return nameElements[nameElements.length - 1];
     }
 
     @Override

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -197,7 +197,8 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration imple
 
     @Override
     public String getName() {
-        return ctClass.getSimpleName();
+        String[] nameElements = ctClass.getSimpleName().replace('$', '.').split("\\.");
+        return nameElements[nameElements.length - 1];
     }
 
     @Override


### PR DESCRIPTION
* until now the method returned Foo$Bar for a type Bar declared inside a type Foo but Foo should only be part of the QualifiedName