### PR TITLE
Add settings to all subprojects to force java compilation and javadoc generation to UTF-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,14 @@ subprojects {
     from sourceSets.main.allSource
   }
 
+  compileJava.options.encoding = 'UTF-8'
+
+  tasks.withType(Javadoc) {
+    options.addStringOption('encoding', 'UTF-8')
+    options.addStringOption('docencoding', 'UTF-8')
+    options.addStringOption('charset', 'UTF-8')
+  }
+
   if (JavaVersion.current().isJava8Compatible()) {
     allprojects {
       tasks.withType(Javadoc) {


### PR DESCRIPTION
Systems that don't have UTF-8 as a default system encoding will fail on the compilation of `com.github.javaparser.symbolsolver.resolution.typeinference.BoundSet.thereIsSomeJSuchThatβequalAlphaJ` . This commit forces that UTF-8 is used for the compilation of java sources and for generating javadoc for those sources. An overview of the relevant javadoc parameters here: https://stackoverflow.com/a/1319706 .