### PR TITLE
Jacoco coverage should include sibling project sources

### DIFF
--- a/java-symbol-solver-testing/build.gradle
+++ b/java-symbol-solver-testing/build.gradle
@@ -16,3 +16,8 @@ idea {
     }
 }
 
+jacocoTestReport {
+    sourceSets project(":java-symbol-solver-model").sourceSets.main
+    sourceSets project(":java-symbol-solver-logic").sourceSets.main
+    sourceSets project(":java-symbol-solver-core").sourceSets.main
+}


### PR DESCRIPTION
Make sure Jacoco picks up the sources of the -model, -logic, -core subprojects when analysing coverage in the -testing subproject. Previously, Jacoco would generate an empty coverage report, because it would only take into account the sources of -testing itself (it has none). This ensures that next to the projects' own sources, extra sources are taken into account for coverage. 

This is a partial fix for #79, in that local coverage is now available. Additional work would be necessary to also push coverage to coveralls.io.

Please note that if the project hierarchy or testing setup is ever revised, this would need revision. In particular, if -core, -model, or -logic get their own tests, special care will be needed to aggregate the coverage on parent-level.