### PR TITLE
[Draft] Issue #326: Javassist*Declaration assignability coverage + ctClass reliance

### DIFF
--- a/java-symbol-solver-testing/build.gradle
+++ b/java-symbol-solver-testing/build.gradle
@@ -25,7 +25,17 @@ jacocoTestReport {
 }
 
 def javassistSymbolsResources = "$projectDir/src/test/resources/javassist_symbols"
+
+/**
+ * Define the various test-jar sources we'll need. The following properties have to be defined:
+ *  - name: String indicating both the name of the folder under the root {@see javassistSymbolsResources} and the name of the jar itself
+ *  - taskNameSuffix: String used to name the various tasks configured for this jar
+ *  - classPath: Array of absolute paths to jars that should be added to the classpath during compilation
+ *  - compileTaskDependencies: Array of tasks which the compile task will depend on
+ *  - buildTaskDependencies: Array of tasks which the jar-building task will depend on
+ */
 def jars = [
+    [name: "assignability", taskNameSuffix: "JavassistAssignability", classPath: ["$javassistSymbolsResources/included_jar/included_jar.jar"], compileTaskDependencies: ["compileTestJarIncludedJar", "buildTestJarIncludedJar"], buildTaskDependencies: []],
     [name: "excluded_jar", taskNameSuffix: "ExcludedJar", classPath: [], compileTaskDependencies: [], buildTaskDependencies: []],
     [name: "included_jar", taskNameSuffix: "IncludedJar", classPath: [], compileTaskDependencies: [], buildTaskDependencies: []],
     [
@@ -37,11 +47,15 @@ def jars = [
     ]
 ]
 
+/**
+ * Will configure a compile and build task for each of the jars defined in `jars`.
+ */
 jars.each { jarToBuild ->
     def fullDir = "$javassistSymbolsResources/${jarToBuild.name}";
     task "compileTestJar${jarToBuild.taskNameSuffix}" (type: JavaCompile, dependsOn: jarToBuild.compileTaskDependencies) {
         destinationDir = new File("$fullDir/result")
         source = "$fullDir/src"
+        // Usage of project.files and the "${->cp}" syntax here is to ensure lazy evaluation of these references, as the jars may the result of other tasks
         classpath = project.files(jarToBuild.classPath.each {cp -> "${->cp}"}, {
             builtBy jarToBuild.compileTaskDependencies
         })
@@ -57,4 +71,5 @@ jars.each { jarToBuild ->
     }
 }
 
-assemble.dependsOn buildTestJarMainJar
+// Add extra dependencies to the built-in assemble task
+assemble.dependsOn buildTestJarMainJar, buildTestJarJavassistAssignability

--- a/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/ChildClassA.java
+++ b/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/ChildClassA.java
@@ -1,0 +1,5 @@
+package com.github.javaparser.javasymbolsolver.javassist_assignability_testdata;
+
+public class ChildClassA extends SuperClassA implements InterfaceA, InterfaceB {
+
+}

--- a/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/ChildClassB.java
+++ b/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/ChildClassB.java
@@ -1,0 +1,5 @@
+package com.github.javaparser.javasymbolsolver.javassist_assignability_testdata;
+
+public class ChildClassB extends SuperClassA implements InterfaceA, InterfaceB {
+
+}

--- a/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/ChildClassCNoInterfaces.java
+++ b/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/ChildClassCNoInterfaces.java
@@ -1,0 +1,5 @@
+package com.github.javaparser.javasymbolsolver.javassist_assignability_testdata;
+
+public class ChildClassCNoInterfaces extends SuperClassA {
+
+}

--- a/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/ChildWithTiesToDifferentJar.java
+++ b/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/ChildWithTiesToDifferentJar.java
@@ -1,0 +1,7 @@
+package com.github.javaparser.javasymbolsolver.javassist_assignability_testdata;
+
+import com.github.javaparser.javasymbolsolver.javassist_symbols.included_jar.*;
+
+public class ChildWithTiesToDifferentJar extends SuperClassIncludedJar implements InterfaceIncludedJar {
+
+}

--- a/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/InterfaceA.java
+++ b/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/InterfaceA.java
@@ -1,0 +1,5 @@
+package com.github.javaparser.javasymbolsolver.javassist_assignability_testdata;
+
+public interface InterfaceA {
+
+}

--- a/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/InterfaceB.java
+++ b/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/InterfaceB.java
@@ -1,0 +1,5 @@
+package com.github.javaparser.javasymbolsolver.javassist_assignability_testdata;
+
+public interface InterfaceB extends InterfaceC {
+
+}

--- a/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/InterfaceC.java
+++ b/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/InterfaceC.java
@@ -1,0 +1,5 @@
+package com.github.javaparser.javasymbolsolver.javassist_assignability_testdata;
+
+public interface InterfaceC {
+
+}

--- a/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/StandaloneClassA.java
+++ b/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/StandaloneClassA.java
@@ -1,0 +1,5 @@
+package com.github.javaparser.javasymbolsolver.javassist_assignability_testdata;
+
+public class StandaloneClassA {
+
+}

--- a/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/SuperClassA.java
+++ b/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/SuperClassA.java
@@ -1,0 +1,5 @@
+package com.github.javaparser.javasymbolsolver.javassist_assignability_testdata;
+
+public class SuperClassA extends SuperClassB {
+
+}

--- a/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/SuperClassB.java
+++ b/java-symbol-solver-testing/src/test/resources/javassist_symbols/assignability/src/com/github/javaparser/javasymbolsolver/javassist_assignability_testdata/SuperClassB.java
@@ -1,0 +1,5 @@
+package com.github.javaparser.javasymbolsolver.javassist_assignability_testdata;
+
+public class SuperClassB {
+
+}


### PR DESCRIPTION
**This PR is in draft status and should not be merged**

The assignability-family of methods in Javassist*Declaration makes use of ctClass.getSuperclass() and ctClass.getInterfaces() where it would be better not to (see #326).

This PR aims to gradually increase test coverage, remove the incorrect ctClass usage, provide missing implementation (for example in JavassistInterfaceDeclaration), and do some refactoring where deemed necessary.