### PR TITLE
Fix issues #300 and #355: Getting the FieldDeclaration from a FieldAccessExpr

### DIFF
--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -28,6 +28,7 @@ import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.types.*;
 import com.github.javaparser.symbolsolver.core.resolution.Context;
+import com.github.javaparser.symbolsolver.javaparsermodel.contexts.FieldAccessContext;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.*;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
@@ -268,6 +269,10 @@ public class JavaParserFacade {
         } else {
             return SymbolReference.unsolved(ResolvedAnnotationDeclaration.class);
         }
+    }
+
+    public SymbolReference<ResolvedFieldDeclaration> solve(FieldAccessExpr fieldAccessExpr) {
+        return ((FieldAccessContext) JavaParserFactory.getContext(fieldAccessExpr, typeSolver)).solveField(fieldAccessExpr.getName().getId(), typeSolver);
     }
 
     public ResolvedType getType(Node node) {

--- a/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/FieldAccessContext.java
+++ b/java-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/FieldAccessContext.java
@@ -20,8 +20,10 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
 import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
@@ -31,6 +33,7 @@ import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.resolution.Value;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -90,5 +93,16 @@ public class FieldAccessContext extends AbstractJavaParserContext<FieldAccessExp
         } else {
             return getParent().solveSymbolAsValue(name, typeSolver);
         }
+    }
+
+    public SymbolReference<ResolvedFieldDeclaration> solveField(String name, TypeSolver typeSolver) {
+        Collection<ResolvedReferenceTypeDeclaration> rrtds = findTypeDeclarations(Optional.of(wrappedNode.getScope()), typeSolver);
+        for (ResolvedReferenceTypeDeclaration rrtd : rrtds) {
+            try {
+                return SymbolReference.solved(rrtd.getField(wrappedNode.getName().getId()));
+            } catch (Throwable t) {
+            }
+        }
+        return SymbolReference.unsolved(ResolvedFieldDeclaration.class);
     }
 }

--- a/java-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue300.java
+++ b/java-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue300.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Federico Tomassetti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseException;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.Test;
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class Issue300 extends AbstractResolutionTest {
+
+    @Test
+    public void fieldAccessIssue() throws ParseException, FileNotFoundException {
+        String pathToSourceFile = adaptPath("src/test/resources/issue300/Issue300.java");
+        CompilationUnit cu = JavaParser.parse(new File(pathToSourceFile));
+
+        final FieldAccessExpr fieldAccess = Navigator.findNodeOfGivenClass(cu, FieldAccessExpr.class);
+        assertNotNull(fieldAccess);
+
+        TypeSolver typeSolver = new CombinedTypeSolver(
+                new ReflectionTypeSolver(),
+                new JavaParserTypeSolver(adaptPath(new File("src/test/resources/issue300"))));
+        final JavaParserFacade javaParserFacade = JavaParserFacade.get(typeSolver);
+        final SymbolReference<? extends ResolvedValueDeclaration> ref = javaParserFacade.solve(fieldAccess);
+        assertEquals(ResolvedPrimitiveType.INT, ref.getCorrespondingDeclaration().getType().asPrimitive());
+    }
+}
+

--- a/java-symbol-solver-testing/src/test/resources/issue300/Issue300.java
+++ b/java-symbol-solver-testing/src/test/resources/issue300/Issue300.java
@@ -1,0 +1,12 @@
+public class Issue300 {
+
+    class A {
+        int i;
+    }
+
+    class B {
+        B() {
+            new A().i = 0;
+        }
+    }
+}


### PR DESCRIPTION
Fix issues #300 and #355.

The logic to get the `ResolvedReferenceTypeDeclaration`'s from a scope and a `TypeSolver` was extracted from `MethodCallExprContext.solveMethod`  to a method named `findTypeDeclarations` and pulled up to `AbstractJavaParserContext` class. After that a method called `FieldAccessContext.solveField` was created. This method uses the `findTypeDeclarations` method mentioned before.